### PR TITLE
Fully automatic GPU offloading of linear solves

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -16,6 +16,25 @@ using FunctionWrappers: FunctionWrapper
 
 using MuladdMacro, Parameters
 
+@static if Base.find_package("CuArrays") !== nothing
+    using CuArrays
+    if Float64(CUDAdrv.totalmem(first(devices()))) > 1e9
+        @info("CUDA support found, automatic GPU acceleration will be enabled.")
+        const GPU_SUPPORTED = true
+        const AUTO_GPU_SIZE = 100
+        cuify(x::CuArray) = CuArrays.CuArray(x)
+    else
+        @info("CUDA support not found, GPU acceleration will not be available.")
+        const GPU_SUPPORTED = false
+        const AUTO_GPU_SIZE = 100
+        cuify(x::CuArray) = x
+    end
+else
+    @info("CUDA support not found, GPU acceleration will not be available.")
+    const GPU_SUPPORTED = false
+    const AUTO_GPU_SIZE = 100
+    cuify(x::CuArray) = x
+end
 
 # Problems
 """

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -22,18 +22,18 @@ using MuladdMacro, Parameters
         @info("CUDA support found, automatic GPU acceleration will be enabled.")
         const GPU_SUPPORTED = true
         const AUTO_GPU_SIZE = 100
-        cuify(x::CuArray) = CuArrays.CuArray(x)
+        cuify(x) = CuArrays.CuArray(x)
     else
         @info("CUDA support not found, GPU acceleration will not be available.")
         const GPU_SUPPORTED = false
         const AUTO_GPU_SIZE = 100
-        cuify(x::CuArray) = x
+        cuify(x) = x
     end
 else
     @info("CUDA support not found, GPU acceleration will not be available.")
     const GPU_SUPPORTED = false
     const AUTO_GPU_SIZE = 100
-    cuify(x::CuArray) = x
+    cuify(x) = x
 end
 
 # Problems

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -18,11 +18,17 @@ using MuladdMacro, Parameters
 
 @static if Base.find_package("CuArrays") !== nothing
     using CuArrays
-    if Float64(CUDAdrv.totalmem(first(devices()))) > 1e9
+    if Float64(CuArrays.CUDAdrv.totalmem(first(CuArrays.CUDAdrv.devices()))) > 1e9
         @info("CUDA support found, automatic GPU acceleration will be enabled.")
         const GPU_SUPPORTED = true
         const AUTO_GPU_SIZE = 100
         cuify(x) = CuArrays.CuArray(x)
+
+        # Piracy, should get upstreamed
+        function ldiv!(x::CuArrays.CuArray,_qr::CuArrays.CUSOLVER.CuQR,b::CuArrays.CuArray)
+          _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
+          x .= vec(_x)
+        end
     else
         @info("CUDA support not found, GPU acceleration will not be available.")
         const GPU_SUPPORTED = false

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -25,7 +25,7 @@ using MuladdMacro, Parameters
         cuify(x) = CuArrays.CuArray(x)
 
         # Piracy, should get upstreamed
-        function ldiv!(x::CuArrays.CuArray,_qr::CuArrays.CUSOLVER.CuQR,b::CuArrays.CuArray)
+        function Base.ldiv!(x::CuArrays.CuArray,_qr::CuArrays.CUSOLVER.CuQR,b::CuArrays.CuArray)
           _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
           x .= vec(_x)
         end

--- a/src/init.jl
+++ b/src/init.jl
@@ -1,5 +1,4 @@
 value(x) = x
-cuify(x) = error("To use LinSolveGPUFactorize, you must do `using CuArrays`")
 
 function __init__()
   @require ApproxFun="28f2ccd6-bb30-5033-b560-165f7b14dc2f" begin
@@ -115,7 +114,6 @@ function __init__()
 
   # Piracy, should get upstreamed
   @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
-    cuify(x::AbstractArray) = CuArrays.CuArray(x)
     function ldiv!(x::CuArrays.CuArray,_qr::CuArrays.CUSOLVER.CuQR,b::CuArrays.CuArray)
       _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
       x .= vec(_x)

--- a/src/init.jl
+++ b/src/init.jl
@@ -111,12 +111,4 @@ function __init__()
     end
     @inline ODE_DEFAULT_NORM(u::Flux.Tracker.TrackedReal,t::Flux.Tracker.TrackedReal) = abs(u)
   end
-
-  # Piracy, should get upstreamed
-  @require CuArrays="3a865a2d-5b23-5a0f-bc46-62713ec82fae" begin
-    function ldiv!(x::CuArrays.CuArray,_qr::CuArrays.CUSOLVER.CuQR,b::CuArrays.CuArray)
-      _x = UpperTriangular(_qr.R) \ (_qr.Q' * reshape(b,length(b),1))
-      x .= vec(_x)
-    end
-  end
 end


### PR DESCRIPTION
Currently throws a warning:

```julia
┌ Warning: Package DiffEqBase does not have CuArrays in its dependencies:
│ - If you have DiffEqBase checked out for development and have
│   added CuArrays as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with DiffEqBase
└ Loading CuArrays into DiffEqBase from project dependency, future warnings for DiffEqBase are suppressed.
```

I think this may warrant some discussion. In DiffEq, we like to have our defaults as "good as possible". This follows the idea of Xeon Phi's which auto-offloaded large matrix computations when it knew it would give a speedup. We would like to similarly do that. This PR is not tuned yet, and we might want a stricter GPU memory restriction (and make sure that the matrix will fit), but that's details. 

The question isn't if we want to do something like this, we definitely want to as an overridable default, but whether this is a good or correct way to do it. Using Requires.jl would require that the user does `using CuArrays` which defaults the whole purpose of this since then it's sensitive to the user remembering to add a using statement but not use the package.

I am curious if @vchuravy and @StefanKarpinski have comments.