### PR TITLE
distinguish Base/Compat as origin of eachcol/eachrow

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.23.0"
+version = "6.23.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/operators/basic_operators.jl
+++ b/src/operators/basic_operators.jl
@@ -99,8 +99,13 @@ Base.convert(::Type{AbstractMatrix}, L::DiffEqArrayOperator) = L.A
 Base.setindex!(L::DiffEqArrayOperator, v, i::Int) = (L.A[i] = v)
 Base.setindex!(L::DiffEqArrayOperator, v, I::Vararg{Int, N}) where {N} = (L.A[I...] = v)
 
-Base.eachcol(L::DiffEqArrayOperator) = eachcol(L.A)
-Base.eachrow(L::DiffEqArrayOperator) = eachrow(L.A)
+if VERSION < v"1.1.0-DEV.792"
+  Compat.eachcol(L::DiffEqArrayOperator) = eachcol(L.A)
+  Compat.eachrow(L::DiffEqArrayOperator) = eachrow(L.A)
+else
+  Base.eachcol(L::DiffEqArrayOperator) = eachcol(L.A)
+  Base.eachrow(L::DiffEqArrayOperator) = eachrow(L.A)
+end
 Base.length(L::DiffEqArrayOperator) = length(L.A)
 Base.iterate(L::DiffEqArrayOperator,args...) = iterate(L.A,args...)
 Base.axes(L::DiffEqArrayOperator) = axes(L.A)


### PR DESCRIPTION
This is based on v6.23.0, and hopefully allows to have a stable version running on Julia v1.0.x.

Closes #465.