### PR TITLE
[RFC] Use TheradsX for EnsembleThreads

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,6 +31,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SuiteSparse = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
 TableTraits = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 TerminalLoggers = "5d786b92-1e48-4d6f-9151-6b4477ca9bed"
+ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 TreeViews = "a2a6695c-b41b-5b7d-aed9-dbfdeacea5d7"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -3,7 +3,7 @@ module DiffEqBase
 using RecipesBase, RecursiveArrayTools,
       Requires, TableTraits, IteratorInterfaceExtensions, TreeViews,
       IterativeSolvers, RecursiveFactorization, Distributed, ArrayInterface,
-      DataStructures
+      DataStructures, ThreadsX
 
 import Logging, LoggingExtras, TerminalLoggers, ConsoleProgressMonitor, ProgressLogging
 

--- a/src/ensemble/basic_ensemble_solve.jl
+++ b/src/ensemble/basic_ensemble_solve.jl
@@ -149,7 +149,7 @@ end
 function solve_batch(prob,alg,::EnsembleThreads,I,pmap_batch_size,kwargs...)
   batch_data = Vector{Any}(undef,length(I))
   let
-    Threads.@threads for batch_idx in axes(batch_data, 1)
+    ThreadsX.foreach(eachindex(axes(batch_data, 1))) do batch_idx
         i = I[batch_idx]
         iter = 1
         new_prob = prob.prob_func(deepcopy(prob.prob),i,iter)


### PR DESCRIPTION
I experimented with using the new threading scheduler for EnsembleThreads via the [newly announced ThreadsX.jl](https://discourse.julialang.org/t/ann-threadsx-jl-parallelized-base-functions/36666/).

I tried a couple of simple benchmarks:
```julia
using OrdinaryDiffEq
using StochasticDiffEq
using BenchmarkTools

prob = ODEProblem((u,p,t)->1.01u,0.5,(0.0,1.0))
function prob_func(prob,i,repeat)
  ODEProblem(prob.f,rand()*prob.u0,prob.tspan)
end
ensemble_prob = EnsembleProblem(prob,prob_func=prob_func)
@btime sim = solve(ensemble_prob,Tsit5(),EnsembleThreads(),trajectories=10000)

# before: 23.914 ms (519532 allocations: 63.47 MiB)
#         25.330 ms (519532 allocations: 63.47 MiB)
# after:  21.165 ms (519745 allocations: 63.50 MiB)
#         22.414 ms (519747 allocations: 63.50 MiB)

function lorenz!(du,u,p,t)
 du[1] = 10.0*(u[2]-u[1])
 du[2] = u[1]*(28.0-u[3]) - u[2]
 du[3] = u[1]*u[2] - (8/3)*u[3]
end

u0 = [1.0;0.0;0.0]
tspan = (0.0,100.0)
prob = ODEProblem(lorenz!,u0,tspan)
ensemble_prob = EnsembleProblem(prob,prob_func=prob_func)
@btime sim = solve(ensemble_prob,Tsit5(),EnsembleThreads(),trajectories=1000)

# before: 614.122 ms (12953567 allocations: 1.34 GiB)
#         605.395 ms (12954899 allocations: 1.34 GiB)
# after:  604.935 ms (12952126 allocations: 1.34 GiB)
#         584.913 ms (12956241 allocations: 1.34 GiB)

function f(du,u,p,t)
  du[1] = p[1] * u[1] - p[2] * u[1]*u[2]
  du[2] = -3 * u[2] + u[1]*u[2]
end

function g(du,u,p,t)
  du[1] = p[3]*u[1]
  du[2] = p[4]*u[2]
end

p = [1.5,1.0,0.1,0.1]
prob = SDEProblem(f,g,[1.0,1.0],(0.0,10.0),p)

function prob_func(prob,i,repeat)
  prob.p[3:4] = 0.3rand(2)
  prob
end

ensemble_prob = EnsembleProblem(prob,prob_func=prob_func)
@btime sim = solve(ensemble_prob,SRIW1(),trajectories=1000)

# before: 126.437 ms (3022810 allocations: 146.93 MiB)
#         128.520 ms (3036721 allocations: 147.54 MiB)
# after:  121.022 ms (3031293 allocations: 147.36 MiB)
#         128.888 ms (3023618 allocations: 146.96 MiB)
```

I think the advantages would be mostly given by the ability to have parallelization within the user function or integration method without over-subscription (if said parallelization is using the new scheduler). The disadvantages of this PR are the fact that it adds a new dependency and that the performance does not seem to be significantly improved.

Obviously, more benchmarks are required to test this on more realistic scenarios, but before that I would like to know if you think this is a good approach.