### PR TITLE
Fix bisection to make it not return tprev

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -717,7 +717,7 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
               end
               iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
             end
-            Θ = bisection(zero_func, (bottom_t,top_t), integrator.tdir)
+            Θ = bisection(zero_func, (bottom_t,top_t), integrator.tdir; noleft=(bottom_t==integrator.tprev))
             if integrator.tdir * Θ < integrator.tdir * min_t
               integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ), Θ)
             end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -567,7 +567,7 @@ end
 # rough implementation, needs multiple type handling
 # always ensures that if r = bisection(f, (x0, x1))
 # then either f(nextfloat(r)) == 0 or f(nextfloat(r)) * f(r) < 0
-function bisection(f, tup, tdir; maxiters=100)
+function bisection(f, tup, tdir; maxiters=100, noleft=false)
   x0, x1 = tup
   fx0x1 = f(x0) * f(x1)
   fzero = zero(fx0x1)
@@ -600,7 +600,7 @@ function bisection(f, tup, tdir; maxiters=100)
         end
       end
     end
-    (left === mid || right === mid) && return left
+    (left === mid || right === mid) && return ((left === tup[1]) && noleft ? right : left)
     if sign(y) === sign(f(left))
       left = mid
     else
@@ -650,7 +650,7 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
             end
             iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
           end
-          Θ = bisection(zero_func, (bottom_t, top_t), integrator.tdir)
+          Θ = bisection(zero_func, (bottom_t, top_t), integrator.tdir; noleft=(bottom_t==integrator.tprev))
           integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ), Θ)
         end
         #Θ = prevfloat(...)

--- a/src/init.jl
+++ b/src/init.jl
@@ -82,7 +82,7 @@ function __init__()
 
     get_tmp(dc::DiffCache, u::AbstractArray) = dc.du
 
-    bisection(f, tup::Tuple{T,T}, tdir) where {T<:ForwardDiff.Dual} = find_zero(f, tup, Roots.AlefeldPotraShi())
+    bisection(f, tup::Tuple{T,T}, tdir; kwargs...) where {T<:ForwardDiff.Dual} = find_zero(f, tup, Roots.AlefeldPotraShi())
   end
 
   @require Measurements="eff96d63-e80a-5855-80a2-b1b0885c5ab7" begin


### PR DESCRIPTION
Fixes https://github.com/SciML/DifferentialEquations.jl/issues/590
The condition function in the issue was such that value of condition at `bottom_t` was -700 and `nextfloat(bottom_t)` was 2000 so our bisection function would have returned `bottom_t`.  There's nothing much we can do in such condition functions, but throwing an error just because there isn't much precision in a very very specific case wasn't good either.
So I made a kwarg which tells if the bisection function can return left most value or not. 

@ChrisRackauckas @BeastyBlacksmith 