### PR TITLE
Fix ensemble plot recipe warning.

### DIFF
--- a/src/ensemble/ensemble_solutions.jl
+++ b/src/ensemble/ensemble_solutions.jl
@@ -110,7 +110,7 @@ end
       xlims --> (-Inf,Inf)
       ylims --> (-Inf,Inf)
       zlims --> (-Inf,Inf)
-      zcolor --> zcolors[i]
+      marker_z --> zcolors[i]
       sim[i]
     end
   end


### PR DESCRIPTION
```
┌ Warning: Attribute alias `zcolor` detected in the user recipe defined for the signature (::EnsembleSolution{Int64,3,Array{ODESolution{Int64,2,Array{Array{Int64,1},1},Nothing,Nothing,Array{Float64,1},Array{Array{Array{Int64,1},1},1},DiscreteProblem{Array{Int64,1},Tuple{Float64,Float64},true,Param{ModelMinimalR4Feedback,Float64},DiscreteFunction{true,DiffEqBase.var"#166#167",Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}},FunctionMap{false},OrdinaryDiffEq.InterpolationData{DiscreteFunction{true,DiffEqBase.var"#166#167",Nothing,Nothing},Array{Array{Int64,1},1},Array{Float64,1},Array{Array{Array{Int64,1},1},1},OrdinaryDiffEq.FunctionMapCache{Array{Int64,1},Array{Int64,1}}},DiffEqBase.DEStats},1}}). To ensure expected behavior it is recommended to use the default attribute `marker_z`.
```

Change `zcolor` to `marker_z` in accordance with suggestion.