### PR TITLE
Callback Fix: Allowing 0 `cb_time`

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -447,7 +447,7 @@ end
     end
 
     # Evaluate condition slightly in future
-    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(typeof(integrator.t)))
+    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(integrator.t))
     tmp_condition = get_condition(integrator, callback, abst)
 
     # Sometimes users may "switch off" the condition after crossing
@@ -525,7 +525,7 @@ end
     end
 
     # Evaluate condition slightly in future
-    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(typeof(integrator.t)))
+    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(integrator.t))
     tmp_condition = get_condition(integrator, callback, abst)
 
     # Sometimes users may "switch off" the condition after crossing

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -756,9 +756,6 @@ end
 function apply_callback!(integrator,callback::Union{ContinuousCallback,VectorContinuousCallback},cb_time,prev_sign,event_idx)
 
   change_t_via_interpolation!(integrator,integrator.tprev+cb_time)
-  if integrator.opts.adaptive
-    integrator.dtpropose = integrator.dt/10
-  end
 
   # handle saveat
   _, savedexactly = savevalues!(integrator)

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -447,7 +447,7 @@ end
     end
 
     # Evaluate condition slightly in future
-    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(integrator.t))
+    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(typeof(integrator.t)))
     tmp_condition = get_condition(integrator, callback, abst)
 
     # Sometimes users may "switch off" the condition after crossing
@@ -525,7 +525,7 @@ end
     end
 
     # Evaluate condition slightly in future
-    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(integrator.t))
+    abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(typeof(integrator.t)))
     tmp_condition = get_condition(integrator, callback, abst)
 
     # Sometimes users may "switch off" the condition after crossing
@@ -633,7 +633,7 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
           Θ = top_t
         else
           if integrator.event_last_time == counter &&
-            abs(zero_func(bottom_t)) < 100abs(integrator.last_event_error) &&
+            abs(zero_func(bottom_t)) <= 100abs(integrator.last_event_error) &&
             prev_sign_index == 1
 
             # Determined that there is an event by derivative
@@ -700,7 +700,7 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
           else
             if integrator.event_last_time == counter &&
               integrator.vector_event_last_time == event_idx &&
-              abs(zero_func(bottom_t)) < 100abs(integrator.last_event_error) &&
+              abs(zero_func(bottom_t)) <= 100abs(integrator.last_event_error) &&
               prev_sign_index == 1
 
               # Determined that there is an event by derivative
@@ -754,10 +754,11 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
 end
 
 function apply_callback!(integrator,callback::Union{ContinuousCallback,VectorContinuousCallback},cb_time,prev_sign,event_idx)
-  if cb_time == zero(typeof(integrator.t))
-    error("Event repeated at the same time. Please report this error")
-  end
+
   change_t_via_interpolation!(integrator,integrator.tprev+cb_time)
+  if integrator.opts.adaptive
+    integrator.dtpropose = integrator.dt/10
+  end
 
   # handle saveat
   _, savedexactly = savevalues!(integrator)

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -99,7 +99,7 @@ ContinuousCallback(condition,affect!,affect_neg!;
                    rootfind=true,
                    save_positions=(true,true),
                    interp_points=10,
-                   dtrelax=1.0,
+                   dtrelax=1,
                    abstol=10eps(),reltol=0) = ContinuousCallback(
                               condition,affect!,affect_neg!,initialize,
                               idxs,
@@ -114,7 +114,7 @@ function ContinuousCallback(condition,affect!;
                    save_positions=(true,true),
                    affect_neg! = affect!,
                    interp_points=10,
-                   dtrelax=1.0,
+                   dtrelax=1,
                    abstol=10eps(),reltol=0)
 
  ContinuousCallback(
@@ -192,7 +192,7 @@ VectorContinuousCallback(condition,affect!,affect_neg!,len;
                          rootfind=true,
                          save_positions=(true,true),
                          interp_points=10,
-                         dtrelax=1.0,
+                         dtrelax=1,
                          abstol=10eps(),reltol=0) = VectorContinuousCallback(
                               condition,affect!,affect_neg!,len,
                               initialize,
@@ -208,7 +208,7 @@ function VectorContinuousCallback(condition,affect!,len;
                    save_positions=(true,true),
                    affect_neg! = affect!,
                    interp_points=10,
-                   dtrelax=1.0,
+                   dtrelax=1,
                    abstol=10eps(),reltol=0)
 
  VectorContinuousCallback(


### PR DESCRIPTION
Very small changes to code and removed that error.
Scripts tested on:

```julia
using OrdinaryDiffEq, Test

lastt = 0.0
f = function (du,u,p,t)
  du[1] = u[2]
  du[2] = -p[1]
end
function condition(u,t,integrator) # Event when event_f(u,t) == 0
  u[1]
end
function affect!(integrator)
  @test integrator.u[1] >= 0
  global lastt
  println("bounce at interval $(integrator.t - lastt)")
  lastt = integrator.t
  integrator.u[2] = -integrator.u[2]
end
cb2 = ContinuousCallback(condition,affect!)
tspan = (0.0,Float64(Inf))
u0 = [50000.0,0.0]
p = 9.8
prob = ODEProblem(f,u0,tspan,p)
integ = init(prob,Tsit5(),callback=cb2,maxiters=Inf,progress=true)
solve!(inter)
```
This one makes the ball go negative (as dt goes very big) on master. Works fine on this PR(watch out, tspan is infinite long so the script wont stop). Reduced dt after callback and solved an `eps` related blunder.

```julia
f = (u,p,t) -> u

function condition(u,t,i)
    (t-0.10)*(t-0.20)*(t-0.30)*(t-0.40)*(t-0.50)*(t-0.60)*(t-0.70)*(t-0.80)*(t-0.90)
end

function affect!(i)
    println("affect!")
    @show i.t
end
cb = ContinuousCallback(condition,affect!)
tspan = (0.0, 1.0)
u0 = 1.0
prob = ODEProblem(f,u0,tspan)
solve(prob,Tsit5(),callback=cb,adaptive=false,dt=0.1)
```
This one throws the non-bracketing error or the cb_time is 0 error. This PR fixes it too.
@ChrisRackauckas 