### PR TITLE
Fix @.. on MArrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.31.0"
+version = "6.31.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/diffeqfastbc.jl
+++ b/src/diffeqfastbc.jl
@@ -42,21 +42,23 @@ preprocess_args(f::typeof(diffeqbc), dest, args::Tuple{}) = ()
 
 # Performance optimization for the common identity scalar case: dest .= val
 @inline copyto!(dest::DiffEqBC, bc::Broadcasted{<:AbstractArrayStyle{0}}) = copyto!(dest.x, bc)
-@inline function copyto!(dest::DiffEqBC, bc::Broadcasted)
-    axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
-    dest′ = dest.x
-    # Performance optimization: broadcast!(identity, dest, A) is equivalent to copyto!(dest, A) if indices match
-    if bc.f === identity && bc.args isa Tuple{AbstractArray} # only a single input argument to broadcast!
-        A = bc.args[1]
-        if axes(dest) == axes(A)
-            return copyto!(dest′, A)
-        end
-    end
-    bcs′ = preprocess(diffeqbc, dest, bc)
-    @simd ivdep for I in eachindex(bcs′)
-        @inbounds dest′[I] = bcs′[I]
-    end
-    return dest′ # return the original array without the wrapper
+for B in (Broadcasted, Broadcasted{<:StaticArrays.StaticArrayStyle}) # fix ambiguity
+  @eval @inline function copyto!(dest::DiffEqBC, bc::$B)
+      axes(dest) == axes(bc) || throwdm(axes(dest), axes(bc))
+      dest′ = dest.x
+      # Performance optimization: broadcast!(identity, dest, A) is equivalent to copyto!(dest, A) if indices match
+      if bc.f === identity && bc.args isa Tuple{AbstractArray} # only a single input argument to broadcast!
+          A = bc.args[1]
+          if axes(dest) == axes(A)
+              return copyto!(dest′, A)
+          end
+      end
+      bcs′ = preprocess(diffeqbc, dest, bc)
+      @simd ivdep for I in eachindex(bcs′)
+          @inbounds dest′[I] = bcs′[I]
+      end
+      return dest′ # return the original array without the wrapper
+  end
 end
 
 # Forcing `broadcasted` to inline is not necessary, since `Vern9` plays well

--- a/src/diffeqfastbc.jl
+++ b/src/diffeqfastbc.jl
@@ -79,12 +79,12 @@ macro ..(x)
     expr = Base.Broadcast.__dot__(x)
     if expr.head in (:(.=), :(.+=), :(.-=), :(.*=), :(./=), :(.\=), :(.^=)) # we exclude `÷=` `%=` `&=` `|=` `⊻=` `>>>=` `>>=` `<<=` because they are for integers
       name = gensym()
-      dest = :(DiffEqBase.diffeqbc($(expr.args[1])))
+      dest = :(diffeqbc($(esc(expr.args[1]))))
       expr.args[1] = name
-      return esc(quote
-                  $name = $dest
-                  $expr
-                 end)
+      return quote
+        $(esc(name)) = $dest
+        $(esc(expr))
+      end
     else
       return esc(expr)
     end


### PR DESCRIPTION
```julia
julia> using StaticArrays

julia> using DiffEqBase: @..
[ Info: Precompiling DiffEqBase [2b5f629d-d688-5b77-993f-72d75c75574e]

julia> a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z = [@MArray(rand(10, 2)) for i in 1:26];

julia> function foo9(a, b, c, d, e, f, g, h, i)
           @.. a = b + 0.1 * (0.2c + 0.3d + 0.4e + 0.5f + 0.6g + 0.6h + 0.6i)
           nothing
       end
foo9 (generic function with 1 method)

julia> function foo9_1(a, b, c, d, e, f, g, h, i)
           @. a = b + 0.1 * (0.2c + 0.3d + 0.4e + 0.5f + 0.6g + 0.6h + 0.6i)
           nothing
       end
foo9_1 (generic function with 1 method)

julia> using BenchmarkTools

julia> @time foo9(a, b, c, d, e, f, g, h, i) # @..
  0.277952 seconds (1.76 M allocations: 79.222 MiB, 10.08% gc time)

julia> @time foo9_1(a, b, c, d, e, f, g, h, i) # @.
  0.975069 seconds (3.39 M allocations: 141.324 MiB, 4.59% gc time)

julia> @btime foo9($a, $b, $c, $d, $e, $f, $g, $h, $i) # @..
  69.400 ns (0 allocations: 0 bytes)

julia> @btime foo9_1($a, $b, $c, $d, $e, $f, $g, $h, $i) # @.
  19.295 μs (720 allocations: 11.88 KiB)
```