### PR TITLE
Reduce threading overheads

### DIFF
--- a/src/ensemble/basic_ensemble_solve.jl
+++ b/src/ensemble/basic_ensemble_solve.jl
@@ -89,8 +89,13 @@ function __solve(prob::AbstractEnsembleProblem,
   end
 
   if num_batches == 1 && prob.reduction === DEFAULT_REDUCTION
-    elapsed_time = @elapsed batch_data = batch_function(1:trajectories)
-    return EnsembleSolution(batch_data,elapsed_time,true)
+    elapsed_time = @elapsed u = batch_function(1:trajectories)
+    if typeof(u) <: Vector{Any}
+      _u = map(i->u[i],1:length(u))
+    else
+      _u = u
+    end
+    return EnsembleSolution(_u,elapsed_time,true)
   end
 
   if prob.u_init === nothing && prob.reduction === DEFAULT_REDUCTION

--- a/src/ensemble/ensemble_problems.jl
+++ b/src/ensemble/ensemble_problems.jl
@@ -12,12 +12,12 @@ end
 
 DEFAULT_PROB_FUNC(prob,i,repeat) = prob
 DEFAULT_OUTPUT_FUNC(sol,i) = (sol,false)
-DEFAULT_REDUCTION(u,data,I) = (append!(u,data),false)
+DEFAULT_REDUCTION(u,data,I) = (reduce(vcat,(u,data)),false)
 EnsembleProblem(prob;
     output_func = DEFAULT_OUTPUT_FUNC,
     prob_func= DEFAULT_PROB_FUNC,
     reduction = DEFAULT_REDUCTION,
-    u_init = [],
+    u_init = nothing,
     safetycopy = prob_func !== DEFAULT_PROB_FUNC) =
     EnsembleProblem(prob,prob_func,output_func,reduction,u_init,safetycopy)
 
@@ -25,5 +25,5 @@ EnsembleProblem(;prob,
     output_func = DEFAULT_OUTPUT_FUNC,
     prob_func= DEFAULT_PROB_FUNC,
     reduction = DEFAULT_REDUCTION,
-    u_init = [], p = nothing, safetycopy = prob_func !== DEFAULT_PROB_FUNC) =
+    u_init = nothing, p = nothing, safetycopy = prob_func !== DEFAULT_PROB_FUNC) =
     EnsembleProblem(prob,prob_func,output_func,reduction,u_init,safetycopy)

--- a/src/ensemble/ensemble_problems.jl
+++ b/src/ensemble/ensemble_problems.jl
@@ -12,7 +12,7 @@ end
 
 DEFAULT_PROB_FUNC(prob,i,repeat) = prob
 DEFAULT_OUTPUT_FUNC(sol,i) = (sol,false)
-DEFAULT_REDUCTION(u,data,I) = (reduce(vcat,(u,data)),false)
+DEFAULT_REDUCTION(u,data,I) = (vcat(u,data),false)
 EnsembleProblem(prob;
     output_func = DEFAULT_OUTPUT_FUNC,
     prob_func= DEFAULT_PROB_FUNC,


### PR DESCRIPTION
```julia
using DiffEqBase
using DiffEqJump
sr = [1.0,2.0,50.]
maj = MassActionJump(sr,[[1 => 1],[1 => 1],[0 => 1]], [[1 => 1], [1 => -1], [1 => 1]])
params = (1.0,2.0,50.)
tspan = (0.,4.)
u0 = [5]
dprob = DiscreteProblem(u0, tspan, params)
jprob = JumpProblem(dprob, Direct(), maj)
@time sol = solve(EnsembleProblem(jprob), SSAStepper(), EnsembleThreads(); trajectories=10)
```

This went from:

```julia
@time for i in 1:10000 solve(EnsembleProblem(jprob), SSAStepper(), EnsembleThreads(); trajectories=1) end
2.280479 seconds (7.66 M allocations: 2.167 GiB, 12.23% gc time)
2.286676 seconds (7.67 M allocations: 2.168 GiB, 11.25% gc time)
2.108825 seconds (7.65 M allocations: 2.166 GiB, 11.20% gc time)
2.238218 seconds (7.66 M allocations: 2.166 GiB, 11.26% gc time)
```

to

```julia
@time for i in 1:10000 solve(EnsembleProblem(jprob), SSAStepper(), EnsembleThreads(); trajectories=1) end
2.109374 seconds (7.49 M allocations: 2.157 GiB, 12.20% gc time)
2.052700 seconds (7.48 M allocations: 2.156 GiB, 11.95% gc time)
2.158824 seconds (7.49 M allocations: 2.157 GiB, 10.77% gc time)
1.998038 seconds (7.49 M allocations: 2.157 GiB, 11.18% gc time)
```

Not huge but it's a boost, and there's some inference fixes around here. Inference isn't fully fixed,

```julia
const _jprob = EnsembleProblem(jprob)
function solves(i)
  solve(_jprob, SSAStepper(), EnsembleThreads(); trajectories=1)
end
@code_warntype solves(1)
```

but it's better. It would be nice if @yingboma took a dive with Cthulhu sometime.