### PR TITLE
make dual norms include the dual terms

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -54,7 +54,7 @@ function __init__()
     totallength(x::AbstractArray) = sum(totallength,x)
 
     @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,::Any) = sqrt(sse(u))
-    @inline ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual},t::Any) = sqrt(sum(x->sse(x),u) / totallength(u))
+    @inline ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual},t::Any) = sqrt(sum(sse,u) / totallength(u))
     @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,::ForwardDiff.Dual) = sqrt(sse(u))
     @inline ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual},::ForwardDiff.Dual) = sqrt(sum(x->sse(x),u) / totallength(u))
 

--- a/src/init.jl
+++ b/src/init.jl
@@ -48,7 +48,7 @@ function __init__()
     @inline fastpow(x::ForwardDiff.Dual, y::ForwardDiff.Dual) = x^y
 
     sse(x::Number) = x^2
-    sse(x::ForwardDiff.Dual) = sse(ForwardDiff.value(x)) + sum(sse.(ForwardDiff.partials(x)))
+    sse(x::ForwardDiff.Dual) = sse(ForwardDiff.value(x)) + sum(sse, ForwardDiff.partials(x))
     totallength(x::Number) = 1
     totallength(x::ForwardDiff.Dual) = totallength(ForwardDiff.value(x)) + sum(totallength.(ForwardDiff.partials(x)))
     totallength(x::AbstractArray) = sum(totallength,x)

--- a/src/init.jl
+++ b/src/init.jl
@@ -50,7 +50,7 @@ function __init__()
     sse(x::Number) = x^2
     sse(x::ForwardDiff.Dual) = sse(ForwardDiff.value(x)) + sum(sse, ForwardDiff.partials(x))
     totallength(x::Number) = 1
-    totallength(x::ForwardDiff.Dual) = totallength(ForwardDiff.value(x)) + sum(totallength.(ForwardDiff.partials(x)))
+    totallength(x::ForwardDiff.Dual) = totallength(ForwardDiff.value(x)) + sum(totallength, ForwardDiff.partials(x))
     totallength(x::AbstractArray) = sum(totallength,x)
 
     @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual,::Any) = sqrt(sse(u))

--- a/test/norm.jl
+++ b/test/norm.jl
@@ -7,7 +7,7 @@ const internalnorm = ODE_DEFAULT_NORM
 val = rand(10)
 par = rand(10)
 u = Dual.(val, par)
-reference = internalnorm(val, 1)
+reference = sqrt((sum(abs2,val) + sum(abs2,par)) / (length(val) + length(par)))
 dual_real = internalnorm(u, 1)
 dual_dual = internalnorm(u, u[1])
 @test reference === dual_real


### PR DESCRIPTION
This changes the norms on dual numbers to include the dual portions. This means that the solution to the ODE under automatic differentiation is not necessarily the same as without. However, https://github.com/SciML/DiffEqSensitivity.jl/issues/273 nicely highlights some edge cases that show that this is somewhat necessary. In that case, the integrator has zero error, and so time steps are unaffected by tolerances which causes gradients to explode since they are not tolerance controlled. This change adds them to the summation and the length, making the solution by dual numbers equivalent to the result of forward sensitivity analysis under the default norm.

@yingboma what do you think?

@pkofod you might want to test this with Pumas. It should give it some more robustness.

Fixes https://github.com/SciML/DiffEqSensitivity.jl/issues/273