### PR TITLE
Use fastmath on abs

### DIFF
--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -1,5 +1,5 @@
 @inline UNITLESS_ABS2(x) = real(abs2(x))
-@inline ODE_DEFAULT_NORM(u::Union{AbstractFloat,Complex},t) = abs(u)
+@inline ODE_DEFAULT_NORM(u::Union{AbstractFloat,Complex},t) = @fastmath abs(u)
 @inline ODE_DEFAULT_NORM(u::Array{T},t) where T<:Union{AbstractFloat,Complex} =
                                          sqrt(real(sum(abs2,u)) / length(u))
 @inline ODE_DEFAULT_NORM(u::StaticArray{T},t) where T<:Union{AbstractFloat,Complex} =


### PR DESCRIPTION
This results in dramatic speedups on complex numbers, and since this is only used in error norm heuristics, it doesn't need to be very accurate anyways.