### PR TITLE
mass matrix I for DynamicalODEFunction

### DIFF
--- a/src/diffeqfunction.jl
+++ b/src/diffeqfunction.jl
@@ -461,7 +461,7 @@ SplitFunction(f::SplitFunction; kwargs...) = f
               jac_prototype,sparsity,Wfact,Wfact_t,paramjac,syms,colorvec)
 end
 
-function DynamicalODEFunction{iip,true}(f1,f2;mass_matrix=(I,I),
+function DynamicalODEFunction{iip,true}(f1,f2;mass_matrix=I,
                                         analytic=nothing,
                                         tgrad=nothing,
                                         jac=nothing,
@@ -484,7 +484,7 @@ function DynamicalODEFunction{iip,true}(f1,f2;mass_matrix=(I,I),
 end
 
 
-function DynamicalODEFunction{iip,false}(f1,f2;mass_matrix=(I,I),
+function DynamicalODEFunction{iip,false}(f1,f2;mass_matrix=I,
                                          analytic=nothing,
                                          tgrad=nothing,
                                          jac=nothing,

--- a/test/norm.jl
+++ b/test/norm.jl
@@ -7,9 +7,9 @@ const internalnorm = ODE_DEFAULT_NORM
 val = rand(10)
 par = rand(10)
 u = Dual.(val, par)
-reference = sqrt((sum(abs2,val) + sum(abs2,par)) / (length(val) + length(par)))
+reference(val, par) = sqrt((sum(abs2,val) + sum(abs2,par)) / (length(val) + length(par)))
 dual_real = internalnorm(u, 1)
 dual_dual = internalnorm(u, u[1])
-@test reference === dual_real
-@test reference == dual_dual
+@test reference(val, par) ≈ dual_real
+@test reference(val, par) ≈ dual_dual
 @test partials(dual_dual, 1) ≈ gradient(x->internalnorm(x, x[1]), val)'par


### PR DESCRIPTION
You know how sometimes you later think that some idea was a really really bad idea? Yes, this was one of them. "It's a pair of ODEs, so it's a pair of mass matrices!". Yeah, but that breaks all implicit solver fallbacks, and even when implicit methods specialized to second order ODEs exist, mass_matrix=I will still work as the special case to catch, so it's just better...

Anyways, it didn't matter until last week when ArrayPartition suddenly became compatible with all implicit solvers, except for the fact that it would fail because the mass matrix was by default a tuple. So, let's fix this and yay, 2nd order ODEs are now better.

Fixes https://github.com/SciML/DiffEqBase.jl/pull/536