### PR TITLE
Make DiffEqArrayOperator ExponentialUtilities.jl compatible

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.39.0"
+version = "6.39.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/operators/basic_operators.jl
+++ b/src/operators/basic_operators.jl
@@ -94,6 +94,7 @@ end
 update_coefficients!(L::DiffEqArrayOperator,u,p,t) = (L.update_func(L.A,u,p,t); L)
 setval!(L::DiffEqArrayOperator, A) = (L.A = A; L)
 isconstant(L::DiffEqArrayOperator) = L.update_func == DEFAULT_UPDATE_FUNC
+Base.similar(L::DiffEqArrayOperator, ::Type{T}, dims::Dims) where T = similar(L.A, T, dims)
 
 # propagate_inbounds here for the getindex fallback
 Base.@propagate_inbounds Base.convert(::Type{AbstractMatrix}, L::DiffEqArrayOperator) = L.A


### PR DESCRIPTION
This is also related to https://github.com/SciML/OrdinaryDiffEq.jl/blob/91175ba20bf3e604f1b3150ec7a1ac49083f6487/src/derivative_utils.jl#L169-L170

It seems that we don't have the ability to express when we can reasonably "concretize" the operator and ask for the type of the concretized operator.