### PR TITLE
make bisection compatible with bigfloat

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -585,7 +585,7 @@ end
 # rough implementation, needs multiple type handling
 # always ensures that if r = bisection(f, (x0, x1))
 # then either f(nextfloat(r)) == 0 or f(nextfloat(r)) * f(r) < 0
-function bisection(f, tup, tdir; maxiters=100)
+function bisection(f, tup, tdir; maxiters=1000)
   x0, x1 = tup
   fx0x1 = f(x0) * f(x1)
   fzero = zero(fx0x1)
@@ -607,7 +607,7 @@ function bisection(f, tup, tdir; maxiters=100)
         iter += 1
         iter == maxiters && error("Maxiters exceeded in bisection. Please report the error in DiffEqBase")
         mid = (left + right) / 2
-        (left === mid || right === mid) && return left
+        (left == mid || right == mid) && return left
         if iszero(f(mid)) && !iszero(f(prevfloat_tdir(mid)))
           return prevfloat_tdir(mid)
         end
@@ -618,8 +618,8 @@ function bisection(f, tup, tdir; maxiters=100)
         end
       end
     end
-    (left === mid || right === mid) && return left
-    if sign(y) === sign(f(left))
+    (left == mid || right == mid) && return left
+    if sign(y) == sign(f(left))
       left = mid
     else
       right = mid

--- a/test/downstream/bigfloat_events.jl
+++ b/test/downstream/bigfloat_events.jl
@@ -1,0 +1,25 @@
+using OrdinaryDiffEq
+
+function lorenz!(du,u,p,t)
+ du[1] = 10.0*(u[2]-u[1])
+ du[2] = u[1]*(28.0-u[3]) - u[2]
+ du[3] = u[1]*u[2] - (8/3)*u[3]
+end
+
+u0 = BigFloat[1.0;0.0;0.0]
+tspan = (big(0.0),big(100.0))
+prob = ODEProblem(lorenz!,u0,tspan)
+sol = solve(prob,Tsit5(),save_everystep=false)
+
+x = sol.u[end]
+
+import LinearAlgebra.norm
+function condition(u,t,integrator)
+    norm(u-x)-0.1
+end
+
+affect!(integrator) = terminate!(integrator)
+
+cb = ContinuousCallback(condition,affect!)
+
+sol2 = solve(prob,Tsit5(),save_everystep=false,callback=cb)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,7 +37,6 @@ end
 
 if !is_APPVEYOR && GROUP == "Downstream"
     activate_downstream_env()
-
     @time @safetestset "Unitful" begin include("downstream/unitful.jl") end
     @time @safetestset "Null Parameters" begin include("downstream/null_params_test.jl") end
     @time @safetestset "Ensemble Simulations" begin include("downstream/ensemble.jl") end
@@ -49,6 +48,7 @@ if !is_APPVEYOR && GROUP == "Downstream"
     @time @safetestset "LabelledArrays Tests" begin include("downstream/labelledarrays.jl") end
     @time @safetestset "ODE Event Tests" begin include("downstream/ode_event_tests.jl") end
     @time @safetestset "Event Detection Tests" begin include("downstream/event_detection_tests.jl") end
+    @time @safetestset "Callback BigFloats" begin include("downstream/bigfloat_events.jl")
     @time @safetestset "PSOS and Energy Conservation Event Detection" begin include("downstream/psos_and_energy_conservation.jl") end
     @time @safetestset "DE stats" begin include("downstream/destats_tests.jl") end
     @time @safetestset "DEDataArray" begin include("downstream/data_array_regression_tests.jl") end
@@ -58,7 +58,6 @@ end
 
 if !is_APPVEYOR && GROUP == "GPU"
     activate_downstream_env()
-
     @time @safetestset "Simple GPU" begin include("gpu/simple_gpu.jl") end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,7 +48,7 @@ if !is_APPVEYOR && GROUP == "Downstream"
     @time @safetestset "LabelledArrays Tests" begin include("downstream/labelledarrays.jl") end
     @time @safetestset "ODE Event Tests" begin include("downstream/ode_event_tests.jl") end
     @time @safetestset "Event Detection Tests" begin include("downstream/event_detection_tests.jl") end
-    @time @safetestset "Callback BigFloats" begin include("downstream/bigfloat_events.jl")
+    @time @safetestset "Callback BigFloats" begin include("downstream/bigfloat_events.jl") end
     @time @safetestset "PSOS and Energy Conservation Event Detection" begin include("downstream/psos_and_energy_conservation.jl") end
     @time @safetestset "DE stats" begin include("downstream/destats_tests.jl") end
     @time @safetestset "DEDataArray" begin include("downstream/data_array_regression_tests.jl") end


### PR DESCRIPTION
`===` is not appropriate unless it's determined by a constant, and it fails on any mutable number (bigfloats). Also the default maxiters was made higher to handle default bigfloat precision

Fixes https://github.com/SciML/DifferentialEquations.jl/issues/653