### PR TITLE
Callback bug fixes

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -661,7 +661,8 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
             diff_t = integrator.tdir*2eps(bottom_t)
             bottom_t += diff_t
             iter = 1
-            while sign(zero_func(bottom_t)) == sign_top && iter < 12
+            # This check should match the same check in bisection
+            while sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) && iter < 12
               diff_t *= 5
               bottom_t = integrator.tprev + diff_t
               iter += 1
@@ -728,7 +729,8 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
               diff_t = integrator.tdir * 2eps(bottom_t)
               bottom_t += diff_t
               iter = 1
-              while sign(zero_func(bottom_t)) == sign_top && iter < 12
+              # This check should match the same check in bisection
+              while sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) && iter < 12
                 diff_t *= 5
                 bottom_t = integrator.tprev + diff_t
                 iter += 1

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -717,7 +717,7 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
             Θ = top_t
           else
             if integrator.event_last_time == counter &&
-              integrator.vector_event_last_time == event_idx &&
+              integrator.vector_event_last_time == idx &&
               abs(zero_func(bottom_t)) <= 100abs(integrator.last_event_error) &&
               prev_sign_index == 1
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -658,7 +658,7 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
             # But floating point error may make the end point negative
 
             sign_top = sign(zero_func(top_t))
-            diff_t = integrator.tdir*2eps(typeof(bottom_t))
+            diff_t = integrator.tdir*2eps(bottom_t)
             bottom_t += diff_t
             iter = 1
             while sign(zero_func(bottom_t)) == sign_top && iter < 12
@@ -725,7 +725,7 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
               # But floating point error may make the end point negative
 
               sign_top = sign(zero_func(top_t))
-              diff_t = integrator.tdir * 2eps(typeof(bottom_t))
+              diff_t = integrator.tdir * 2eps(bottom_t)
               bottom_t += diff_t
               iter = 1
               while sign(zero_func(bottom_t)) == sign_top && iter < 12


### PR DESCRIPTION
In using VectorContinuousCallback in my code I came across several bugs, leading to exceptions, which I think I've fixed here.

1. The check `integrator.vector_event_last_time == event_idx` compared an Int to a Vector{Int} so it would always be false. I think it should be `idx` instead of `event_idx`.
2. The `diff_t` used in the nudging of the bottom t to find a different sign for bottom and top was using machine epsilon of the type, not the actual time. In my particular case, t was very large causing this to fail.
3. The check between `find_callback_time` and `bisection` was inconsistent. The nudger in `find_callback_time` was happy with a zero value for bottom_t, but `bisection` wanted a non-zero value.

I wanted to write some tests for this but ran out of time and figured that these are simple enough fixes. All the existing tests of `DiffEqBase` and `OrdinaryDiffEq` pass on my machine.