### PR TITLE
Fixed inference issues in bisection and CallbackCache

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -882,7 +882,7 @@ function CallbackCache(u,max_len,::Type{conditionType},::Type{signType}) where {
     previous_condition = similar(u, conditionType, max_len)
     next_sign = similar(u, signType, max_len)
     prev_sign = similar(u, signType, max_len)
-    CallbackCache{typeof(tmp_condition),typeof(next_sign)}(tmp_condition,previous_condition,next_sign,prev_sign)
+    CallbackCache(tmp_condition,previous_condition,next_sign,prev_sign)
 end
 
 function CallbackCache(max_len,::Type{conditionType},::Type{signType}) where {conditionType,signType}
@@ -890,5 +890,5 @@ function CallbackCache(max_len,::Type{conditionType},::Type{signType}) where {co
     previous_condition = zeros(conditionType, max_len)
     next_sign = zeros(signType, max_len)
     prev_sign = zeros(signType, max_len)
-    CallbackCache{typeof(tmp_condition),typeof(next_sign)}(tmp_condition,previous_condition,next_sign,prev_sign)
+    CallbackCache(tmp_condition,previous_condition,next_sign,prev_sign)
 end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -590,7 +590,10 @@ function bisection(f, tup, tdir ; maxiters=1000)
   fx0x1 = f(x0) * f(x1)
   fzero = zero(fx0x1)
   (fx0x1 >= fzero) && error("Non bracketing interval passed in bisection method. Please report the error in DiffEqBase.")
-  prevfloat_tdir(t,forward=isone(tdir)) = forward ? prevfloat(t) : nextfloat(t)
+  # The comment line below does not allow for inference, yet the second version does.
+  forward=isone(tdir)
+  #prevfloat_tdir = forward ? prevfloat : nextfloat
+  prevfloat_tdir(t) = forward ? prevfloat(t) : nextfloat(t)
   left = x0
   right = x1
   iter = 0

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -585,12 +585,12 @@ end
 # rough implementation, needs multiple type handling
 # always ensures that if r = bisection(f, (x0, x1))
 # then either f(nextfloat(r)) == 0 or f(nextfloat(r)) * f(r) < 0
-function bisection(f, tup, tdir, prevfloat_tdir=isone(tdir) ? prevfloat : nextfloat
-                   ; maxiters=1000)
+function bisection(f, tup, tdir ; maxiters=1000)
   x0, x1 = tup
   fx0x1 = f(x0) * f(x1)
   fzero = zero(fx0x1)
   (fx0x1 >= fzero) && error("Non bracketing interval passed in bisection method. Please report the error in DiffEqBase.")
+  prevfloat_tdir(t,forward=isone(tdir)) = forward ? prevfloat(t) : nextfloat(t)
   left = x0
   right = x1
   iter = 0

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -590,9 +590,7 @@ function bisection(f, tup, tdir ; maxiters=1000)
   fx0x1 = f(x0) * f(x1)
   fzero = zero(fx0x1)
   (fx0x1 >= fzero) && error("Non bracketing interval passed in bisection method. Please report the error in DiffEqBase.")
-  # The comment line below does not allow for inference, yet the second version does.
   forward=isone(tdir)
-  #prevfloat_tdir = forward ? prevfloat : nextfloat
   prevfloat_tdir(t) = forward ? prevfloat(t) : nextfloat(t)
   left = x0
   right = x1

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -585,14 +585,14 @@ end
 # rough implementation, needs multiple type handling
 # always ensures that if r = bisection(f, (x0, x1))
 # then either f(nextfloat(r)) == 0 or f(nextfloat(r)) * f(r) < 0
-function bisection(f, tup, tdir; maxiters=1000)
+function bisection(f, tup, tdir, prevfloat_tdir=isone(tdir) ? prevfloat : nextfloat
+                   ; maxiters=1000)
   x0, x1 = tup
   fx0x1 = f(x0) * f(x1)
   fzero = zero(fx0x1)
   (fx0x1 >= fzero) && error("Non bracketing interval passed in bisection method. Please report the error in DiffEqBase.")
   left = x0
   right = x1
-  prevfloat_tdir = isone(tdir) ? prevfloat : nextfloat
   iter = 0
   while true
     iter += 1
@@ -890,5 +890,5 @@ function CallbackCache(max_len,::Type{conditionType},::Type{signType}) where {co
     previous_condition = zeros(conditionType, max_len)
     next_sign = zeros(signType, max_len)
     prev_sign = zeros(signType, max_len)
-    CallbackCache{Array{conditionType},Array{signType}}(tmp_condition,previous_condition,next_sign,prev_sign)
+    CallbackCache{typeof(tmp_condition),typeof(next_sign)}(tmp_condition,previous_condition,next_sign,prev_sign)
 end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -585,13 +585,12 @@ end
 # rough implementation, needs multiple type handling
 # always ensures that if r = bisection(f, (x0, x1))
 # then either f(nextfloat(r)) == 0 or f(nextfloat(r)) * f(r) < 0
-function bisection(f, tup, tdir ; maxiters=1000)
+function bisection(f, tup, t_forward::Bool ; maxiters=1000)
   x0, x1 = tup
   fx0x1 = f(x0) * f(x1)
   fzero = zero(fx0x1)
   (fx0x1 >= fzero) && error("Non bracketing interval passed in bisection method. Please report the error in DiffEqBase.")
-  forward=isone(tdir)
-  prevfloat_tdir(t) = forward ? prevfloat(t) : nextfloat(t)
+  prevfloat_tdir(t) = t_forward ? prevfloat(t) : nextfloat(t)
   left = x0
   right = x1
   iter = 0
@@ -670,7 +669,7 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
             end
             iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
           end
-          Θ = bisection(zero_func, (bottom_t, top_t), integrator.tdir)
+          Θ = bisection(zero_func, (bottom_t, top_t), isone(integrator.tdir))
           integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ), Θ)
         end
         #Θ = prevfloat(...)
@@ -738,7 +737,7 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
               end
               iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
             end
-            Θ = bisection(zero_func, (bottom_t,top_t), integrator.tdir)
+            Θ = bisection(zero_func, (bottom_t,top_t), isone(integrator.tdir))
             if integrator.tdir * Θ < integrator.tdir * min_t
               integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ), Θ)
             end

--- a/src/init.jl
+++ b/src/init.jl
@@ -94,7 +94,7 @@ function __init__()
     get_tmp(dc::DiffCache, u::Number) = dc.du
     get_tmp(dc::DiffCache, u::AbstractArray) = dc.du
 
-    bisection(f, tup::Tuple{T,T}, tdir) where {T<:ForwardDiff.Dual} = find_zero(f, tup, Roots.AlefeldPotraShi())
+    bisection(f, tup::Tuple{T,T}, t_forward::Bool) where {T<:ForwardDiff.Dual} = find_zero(f, tup, Roots.AlefeldPotraShi())
   end
 
   @require Measurements="eff96d63-e80a-5855-80a2-b1b0885c5ab7" begin


### PR DESCRIPTION
In following up my inference issues identified in #574, I think I found another couple of bugs.

1. The `prevfloat_tdir` variable in `bisection(...)` doesn't seem to be expanded into its two possibilities by the compiler, so the return value of the function was an `Any`. I "fixed" this by putting it as an argument to the function with a default. This feels like a dirty hack to me... is there a better way to get the same result?

2. One of the `CallbackCache` constructors (which is used only for `VectorContinuousCallback`) was setting the parameters to be `Array{Float64}` without a dimension, so it would appear as `Array{Float64,N}` in my integrator object. I don't think Array was the intent anyway, so I changed it to be the same as the other constructor, which is `typeof(tmp_condition)`.