### PR TITLE
Add missing has_continuous_callback(::VectorContinuousCallback) method

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -333,6 +333,7 @@ Base.isempty(cb::AbstractDiscreteCallback) = false
 
 has_continuous_callback(cb::DiscreteCallback) = false
 has_continuous_callback(cb::ContinuousCallback) = true
+has_continuous_callback(cb::VectorContinuousCallback) = true
 has_continuous_callback(cb::CallbackSet) = !isempty(cb.continuous_callbacks)
 has_continuous_callback(cb::Nothing) = false
 


### PR DESCRIPTION
Fix for https://github.com/SciML/DifferentialEquations.jl/issues/662

Reproduced here for quick reference:

---

When trying to forward diff through an ODE with a `VectorContinuousCallback`, I’m getting:
```
ERROR: MethodError: no method matching has_continuous_callback(::DiffEqBase.VectorContinuousCallback{...})
```

Tracing through a little more, I find that `has_continuous_callback()` is called if `ForwardDiff` is loaded, but they are only defined for:

```
has_continuous_callback(cb::DiscreteCallback) = false
has_continuous_callback(cb::ContinuousCallback) = true
has_continuous_callback(cb::CallbackSet) = !isempty(cb.continuous_callbacks)
has_continuous_callback(cb::Nothing) = false
```
and not for `VectorContinuousCallback`.
