### PR TITLE
Guard against invalid DAEProblems

### DIFF
--- a/src/problems/dae_problems.jl
+++ b/src/problems/dae_problems.jl
@@ -14,6 +14,11 @@ struct DAEProblem{uType,duType,tType,isinplace,P,F,K,D} <: AbstractDAEProblem{uT
                       du0,u0,tspan,p=NullParameters();
                       differential_vars = nothing,
                       kwargs...) where {iip}
+    # Defend against external solvers like Sundials breaking on non-uniform input dimensions.
+    size(du0) == size(u0) || throw(ArgumentError("Sizes of u0 and du0 must be the same."))
+    if !isnothing(differential_vars)
+        size(u0) == size(differential_vars) || throw(ArgumentError("Sizes of u0 and differential_vars must be the same."))
+    end
     _tspan = promote_tspan(tspan)
     new{typeof(u0),typeof(du0),typeof(_tspan),
                isinplace(f),typeof(p),

--- a/test/problem_creation_tests.jl
+++ b/test/problem_creation_tests.jl
@@ -85,11 +85,18 @@ function f(r, yp, y, p,tres)
 end
 u0 = [1.0, 0, 0]
 du0 = [-0.04, 0.04, 0.0]
+differential_vars = [true, true, false]
+
 prob_dae_resrob = DAEProblem(f,du0,u0,(0.0,100000.0))
 prob_dae_resrob = DAEProblem{true}(f,du0,u0,(0.0,100000.0))
 
 @test_broken @inferred DAEProblem(f,du0,u0,(0.0,100000.0))
 @test_broken @inferred DAEProblem{true}(f,du0,u0,(0.0,100000.0))
+
+# Ensures uniform dimensionality of u0, du0, and differential_vars
+@test_throws ArgumentError DAEProblem(f,du0,u0[1:end-1],(0.0,100000.0))
+@test_throws ArgumentError DAEProblem(f,du0,u0,(0.0,100000.0);
+                                      differential_vars=differential_vars[1:end-1])
 
 f(u,t,W) = 1.01u.+0.87u.*W
 u0 = 1.00


### PR DESCRIPTION
Require uniform dimensionality between u0, du0, and differential_vars. Should prevent undefined memory access in
Sundials.jl when invalid inputs are passed.

Fixes #581 