### PR TITLE
Fix L(u,p,t) call for AffineDiffEqOperator

### DIFF
--- a/src/operators/diffeq_operator.jl
+++ b/src/operators/diffeq_operator.jl
@@ -92,9 +92,16 @@ Base.size(L::AffineDiffEqOperator) = size(L.As[1])
 
 
 function (L::AffineDiffEqOperator)(u,p,t::Number)
-    tmp = sum((update_coefficients(A,u,p,t); A*u for A in L.As))
-    tmp2 = sum((typeof(B) <: Union{Number,AbstractArray} ? B : B(t) for B in L.Bs))
-    tmp + tmp2
+    update_coefficients!(L,u,p,t)
+    du = sum(A*u for A in L.As)
+    for B in L.Bs
+        if typeof(B) <: Union{Number,AbstractArray}
+            du .+= B
+        else
+            du .+= B(t)
+        end
+    end
+    du
 end
 
 function (L::AffineDiffEqOperator)(du,u,p,t::Number)

--- a/test/affine_operators_tests.jl
+++ b/test/affine_operators_tests.jl
@@ -1,5 +1,6 @@
 using DiffEqBase
 using Test
+using Random
 
 mutable struct TestDiffEqOperator{T} <: DiffEqBase.AbstractDiffEqLinearOperator{T}
     m::Int

--- a/test/affine_operators_tests.jl
+++ b/test/affine_operators_tests.jl
@@ -16,3 +16,20 @@ A = TestDiffEqOperator([0 0; 0 1])
 B = TestDiffEqOperator([0 0 0; 0 1 0; 0 0 2])
 
 @test_throws ErrorException AffineDiffEqOperator{Int64}((A,B),())
+
+@testset "DiffEq linear operators" begin
+    Random.seed!(0)
+    M = rand(2,2); A = DiffEqArrayOperator(M)
+    b = rand(2)
+    u = rand(2)
+    p = rand(1)
+    t = rand()
+    As_list = [(A,), (A, A)]#, (A, α)]
+    bs_list = [(), (b,), (2b,), (b, 2b)]
+    @testset "combinations of A's and b's" for As in As_list, bs in bs_list
+        L = AffineDiffEqOperator{Float64}(As, bs, zeros(2))
+        mysum = sum(A*u for A in As)
+        for b in bs; mysum .+= b; end
+        @test L(u,p,t) == mysum
+    end
+end


### PR DESCRIPTION
This PR fixes (I hope) calls of the type `L(u,p,t)` for `L::AffineDiffEqOperator`.

I think there was a number of mistakes in this function (e.g., the spurious double parentheses in `sum((...))`).

Also, I thought that once `tmp` is created with the `A*u` terms, we could add the `B`s to it inplace. (So I renamed `tmp` as `du` to clarify that, but maybe that's not good practice?)

