### PR TITLE
INITIALIZE_DEFAULT / FINALIZE_DEFAULT => initialize! / finalize!

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -1,7 +1,10 @@
 # Necessary to have initialize set u_modified to false if all don't do anything
 # otherwise unnecessary save
-INITIALIZE_DEFAULT(cb,u,t,integrator) = u_modified!(integrator, false)
-FINALIZE_DEFAULT(cb,u,t,integrator) = nothing
+initialize!(cb,u,t,integrator) = u_modified!(integrator, false)
+finalize!(cb,u,t,integrator) = nothing
+
+const INITIALIZE_DEFAULT = initialize!
+const FINALIZE_DEFAULT = finalize!
 
 
 """


### PR DESCRIPTION
We want to be able to define callbacks that have predefined initializer/finalizers, e.g.
```
struct Diagnostics
  # some stuff
end
DiffEqBase.initialize!(d::Diagnostics, u, t, integrator) = # set up stuff
DiffEqBase.finalize!(d::Diagnostics, u, t, integrator) = # finalize stuff

DiscreteCallback(mycond, Diagnostics(details)) # don't need to pass explicit initializer / finalizer functions
```

We could do this now by defining additional methods for `INITIALIZE_DEFAULT` / `FINALIZE_DEFAULT`, but this seems a bit clearer.

If you're on board, I can add some docs.