### PR TITLE
Fix docstring for deleteat!

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -22,7 +22,6 @@ Base.resize!(i::DEIntegrator,ii::Int) = error("resize!: method has not been impl
 
 Shrinks the ODE by deleting the `idxs` components.
 """
-
 Base.deleteat!(i::DEIntegrator,ii) = error("deleteat!: method has not been implemented for the integrator")
 
 """


### PR DESCRIPTION
There was a stray newline between the docstring and the function which seems to have caused the docstring to not be associated with the function. This means that the docs site can't find the docstring and shows an error instead.