### PR TITLE
Extended recursive_length to operate on Number type

### DIFF
--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -3,6 +3,7 @@
 @inline UNITLESS_ABS2(x::ArrayPartition) = sum(UNITLESS_ABS2, x.x)
 
 @inline recursive_length(u::AbstractArray{<:Number}) = length(u)
+@inline recursive_length(u::Number) = 1
 @inline recursive_length(u::AbstractArray{<:AbstractArray}) = sum(recursive_length, u)
 @inline recursive_length(u::ArrayPartition) = sum(recursive_length, u.x)
 @inline recursive_length(u::VectorOfArray) = sum(recursive_length, u.u)

--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -3,7 +3,7 @@
 @inline UNITLESS_ABS2(x::ArrayPartition) = sum(UNITLESS_ABS2, x.x)
 
 @inline recursive_length(u::AbstractArray{<:Number}) = length(u)
-@inline recursive_length(u::Number) = 1
+@inline recursive_length(u::Number) = length(u)
 @inline recursive_length(u::AbstractArray{<:AbstractArray}) = sum(recursive_length, u)
 @inline recursive_length(u::ArrayPartition) = sum(recursive_length, u.x)
 @inline recursive_length(u::VectorOfArray) = sum(recursive_length, u.u)

--- a/test/ode_default_norm.jl
+++ b/test/ode_default_norm.jl
@@ -2,6 +2,8 @@ using Test, RecursiveArrayTools, StaticArrays
 
 using DiffEqBase: UNITLESS_ABS2, recursive_length,  ODE_DEFAULT_NORM
 
+@test recursive_length(1.0) == 1
+
 n = UNITLESS_ABS2(3.0+4.0im)
 @test n == 25.0
 @test typeof(n)<:Real

--- a/test/ode_default_norm.jl
+++ b/test/ode_default_norm.jl
@@ -32,3 +32,8 @@ u5 = ArrayPartition(u4, u4)
 @test UNITLESS_ABS2(u5) == 50.0
 @test recursive_length(u5) == 50
 @test ODE_DEFAULT_NORM(u5, 0.0) == 1.0
+
+u6 = ArrayPartition(1.0,1.0)
+@test UNITLESS_ABS2(u6) == 2.0
+@test recursive_length(u6) == 2
+@test ODE_DEFAULT_NORM(u6, 0.0) == 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,7 @@ if GROUP == "All" || GROUP == "Core"
     @time @safetestset "Basic Operators Interface" begin include("basic_operators_interface.jl") end
     @time @safetestset "Norm" begin include("norm.jl") end
     @time @safetestset "Utils" begin include("utils.jl") end
+    @time @safetestset "ODE default norm" begin include("ode_default_norm.jl") end
 end
 
 if !is_APPVEYOR && GROUP == "Downstream"


### PR DESCRIPTION
This ensures that it does not fail for ArrayPartitions of Numbers. Will be helpful for fixing https://github.com/SciML/OrdinaryDiffEq.jl/issues/1308

Also, added ode_default_norm tests to `runtests.jl`. Previously missing.