### PR TITLE
Fixes ODE_DEFAULT_UNSTABLE_CHECK on sophisticated nested arrays.

### DIFF
--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -20,11 +20,11 @@
 @inline ODE_DEFAULT_ISOUTOFDOMAIN(u,p,t) = false
 @inline ODE_DEFAULT_PROG_MESSAGE(dt,u,p,t) =
            "dt="*string(dt)*"\nt="*string(t)*"\nmax u="*string(maximum(abs.(u)))
+
+@inline NAN_CHECK(x::Number) = isnan(x)
+@inline NAN_CHECK(x::Float64) = isnan(x) || (x>1e50)
+@inline NAN_CHECK(x::AbstractArray) = any(NAN_CHECK, x)
+@inline NAN_CHECK(x::ArrayPartition) = any(NAN_CHECK, x.x)
+
 @inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u,p,t) = false
-@inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u::AbstractFloat,p,t) = isnan(u)
-@inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u::Float64,p,t) =
-                                                any(x->(isnan(x) || x>1e50),u)
-@inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u::AbstractArray{T},p,t) where
-                                    {T<:AbstractFloat} = any(isnan,u)
-@inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u::ArrayPartition,p,t) =
-                                                 any(any(isnan,x) for x in u.x)
+@inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u::Union{Number,AbstractArray},p,t) = NAN_CHECK(u)

--- a/test/ode_default_unstable_check.jl
+++ b/test/ode_default_unstable_check.jl
@@ -2,38 +2,38 @@ using Test, RecursiveArrayTools, StaticArrays
 
 using DiffEqBase: NAN_CHECK
 
-@test NAN_CHECK(3.0+4.0im) == false
-@test NAN_CHECK(NaN) == true
+@test !NAN_CHECK(3.0+4.0im)
+@test NAN_CHECK(NaN)
 
 u1 = ones(3)
-@test NAN_CHECK(u1) == false
+@test !NAN_CHECK(u1)
 u1′ = copy(u1)
 u1′[2] = NaN
-@test NAN_CHECK(u1′) == true
+@test NAN_CHECK(u1′)
 
 
 u2 = [SA[1.0 1.0; 1.0 1.0] for i = 1:3]
-@test NAN_CHECK(u2) == false
+@test !NAN_CHECK(u2)
 u2′ = copy(u2)
 u2′[2] = SA[1.0 NaN; 1.0 1.0]
-@test NAN_CHECK(u2′) == true
+@test NAN_CHECK(u2′)
 
 u3 = VectorOfArray([ones(5), ones(5)])
-@test NAN_CHECK(u3) == false
+@test !NAN_CHECK(u3)
 u3′ = recursivecopy(u3)
 u3′[2][3] = NaN
-@test NAN_CHECK(u3′) == true
+@test NAN_CHECK(u3′)
 
 u4 = ArrayPartition(u1, u2, u3)
-@test NAN_CHECK(u4) == false
+@test !NAN_CHECK(u4)
 u4_1 = ArrayPartition(u1′, u2, u3)
-@test NAN_CHECK(u4_1) == true
+@test NAN_CHECK(u4_1)
 u4_2 = ArrayPartition(u1, u2′, u3)
-@test NAN_CHECK(u4_2) == true
+@test NAN_CHECK(u4_2)
 u4_3 = ArrayPartition(u1, u2, u3′)
-@test NAN_CHECK(u4_3) == true
+@test NAN_CHECK(u4_3)
 
-@test NAN_CHECK(ArrayPartition(u4, u4)) == false
-@test NAN_CHECK(ArrayPartition(u4, u4_1)) == true
-@test NAN_CHECK(ArrayPartition(u4, u4_2)) == true
-@test NAN_CHECK(ArrayPartition(u4, u4_3)) == true
+@test !NAN_CHECK(ArrayPartition(u4, u4))
+@test NAN_CHECK(ArrayPartition(u4, u4_1))
+@test NAN_CHECK(ArrayPartition(u4, u4_2))
+@test NAN_CHECK(ArrayPartition(u4, u4_3))

--- a/test/ode_default_unstable_check.jl
+++ b/test/ode_default_unstable_check.jl
@@ -1,0 +1,39 @@
+using Test, RecursiveArrayTools, StaticArrays
+
+using DiffEqBase: NAN_CHECK
+
+@test NAN_CHECK(3.0+4.0im) == false
+@test NAN_CHECK(NaN) == true
+
+u1 = ones(3)
+@test NAN_CHECK(u1) == false
+u1′ = copy(u1)
+u1′[2] = NaN
+@test NAN_CHECK(u1′) == true
+
+
+u2 = [SA[1.0 1.0; 1.0 1.0] for i = 1:3]
+@test NAN_CHECK(u2) == false
+u2′ = copy(u2)
+u2′[2] = SA[1.0 NaN; 1.0 1.0]
+@test NAN_CHECK(u2′) == true
+
+u3 = VectorOfArray([ones(5), ones(5)])
+@test NAN_CHECK(u3) == false
+u3′ = recursivecopy(u3)
+u3′[2][3] = NaN
+@test NAN_CHECK(u3′) == true
+
+u4 = ArrayPartition(u1, u2, u3)
+@test NAN_CHECK(u4) == false
+u4_1 = ArrayPartition(u1′, u2, u3)
+@test NAN_CHECK(u4_1) == true
+u4_2 = ArrayPartition(u1, u2′, u3)
+@test NAN_CHECK(u4_2) == true
+u4_3 = ArrayPartition(u1, u2, u3′)
+@test NAN_CHECK(u4_3) == true
+
+@test NAN_CHECK(ArrayPartition(u4, u4)) == false
+@test NAN_CHECK(ArrayPartition(u4, u4_1)) == true
+@test NAN_CHECK(ArrayPartition(u4, u4_2)) == true
+@test NAN_CHECK(ArrayPartition(u4, u4_3)) == true


### PR DESCRIPTION
There is a problem with the current implementation of `ODE_DEFAULT_UNSTABLE_CHECK` in common_defaults.jl.
- First of all, it does not work well with a `Vector` of `StaticArray`s: it tries to call `isnan` on `StaticArray` and this is not defined.
- Analogously, there is a problem with sophisticated variants of `ArrayPartition`: if `ArrayPartition` contains another `ArrayPartition`, it will try to call `isnan` on `ArrayPartition` which is, again, not defined. A `Vector` of `StaticArray`s inside an `ArrayPartition` breaks things as well.

This PR fixes these problems. The function `ODE_DEFAULT_UNSTABLE_CHECK` now calles another function, `NAN_CHECK`, which handles `isnan` for the nested subarrays recursively. Basically, `NAN_CHECK` defines the appropriate dispatch of `isnan` for various array types. (One could also just simply extend `Base.isnan`, however, this would lead to a case of type piracy).