### PR TITLE
Implement Base.IteratorSize for integrator iterators

### DIFF
--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -416,6 +416,7 @@ function Base.iterate(tup::IntegratorTuples, state=0)
   return (tup.integrator.u,tup.integrator.t),state
 end
 
+Base.eltype(::Type{IntegratorTuples{I}}) where {U, T, I<:DEIntegrator{<:Any, <:Any, U, T}} = Tuple{U, T} 
 Base.IteratorSize(::Type{<:IntegratorTuples}) = Base.SizeUnknown()
 
 RecursiveArrayTools.tuples(integrator::DEIntegrator) = IntegratorTuples(integrator)
@@ -435,6 +436,7 @@ function Base.iterate(tup::IntegratorIntervals,state=0)
   return (tup.integrator.uprev,tup.integrator.tprev,tup.integrator.u,tup.integrator.t),state
 end
 
+Base.eltype(::Type{IntegratorIntervals{I}}) where {U, T, I<:DEIntegrator{<:Any, <:Any, U, T}} = Tuple{U, T, U, T} 
 Base.IteratorSize(::Type{<:IntegratorIntervals}) = Base.SizeUnknown()
 
 intervals(integrator::DEIntegrator) = IntegratorIntervals(integrator)
@@ -471,6 +473,8 @@ function Base.iterate(iter::TimeChoiceIterator,state=1)
     return (tmp,t),state+1
   end
 end
+
+Base.length(iter::TimeChoiceIterator) = length(iter.ts)
 
 @recipe function f(integrator::DEIntegrator;
                     denseplot=(integrator.opts.calck || typeof(integrator) <: AbstractSDEIntegrator)  && integrator.iter>0,

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -416,7 +416,7 @@ function Base.iterate(tup::IntegratorTuples, state=0)
   return (tup.integrator.u,tup.integrator.t),state
 end
 
-Base.IteratorSize(::Type{IntegratorTuples{T}}) where T<:DEIntegrator = Base.SizeUnknown()
+Base.IteratorSize(::Type{<:IntegratorTuples}) = Base.SizeUnknown()
 
 RecursiveArrayTools.tuples(integrator::DEIntegrator) = IntegratorTuples(integrator)
 

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -400,7 +400,7 @@ function Base.iterate(integrator::DEIntegrator,state=0)
 end
 
 Base.eltype(integrator::DEIntegrator) = typeof(integrator)
-Base.IteratorSize(::Type{T}) where T<:DEIntegrator = Base.SizeUnknown()
+Base.IteratorSize(::Type{<:DEIntegrator}) = Base.SizeUnknown()
 
 ### Other Iterators
 

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -400,6 +400,7 @@ function Base.iterate(integrator::DEIntegrator,state=0)
 end
 
 Base.eltype(integrator::DEIntegrator) = typeof(integrator)
+Base.IteratorSize(::Type{T}) where T<:DEIntegrator = Base.SizeUnknown()
 
 ### Other Iterators
 
@@ -414,6 +415,8 @@ function Base.iterate(tup::IntegratorTuples, state=0)
   # Next is callbacks -> iterator  -> top
   return (tup.integrator.u,tup.integrator.t),state
 end
+
+Base.IteratorSize(::Type{IntegratorTuples{T}}) where T<:DEIntegrator = Base.SizeUnknown()
 
 RecursiveArrayTools.tuples(integrator::DEIntegrator) = IntegratorTuples(integrator)
 
@@ -431,6 +434,8 @@ function Base.iterate(tup::IntegratorIntervals,state=0)
   # Next is callbacks -> iterator  -> top
   return (tup.integrator.uprev,tup.integrator.tprev,tup.integrator.u,tup.integrator.t),state
 end
+
+Base.IteratorSize(::Type{IntegratorIntervals{T}}) where T<:DEIntegrator = Base.SizeUnknown()
 
 intervals(integrator::DEIntegrator) = IntegratorIntervals(integrator)
 

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -399,7 +399,7 @@ function Base.iterate(integrator::DEIntegrator,state=0)
   return integrator,state
 end
 
-Base.eltype(integrator::DEIntegrator) = typeof(integrator)
+Base.eltype(::Type{T}) where {T<:DEIntegrator} = T
 Base.IteratorSize(::Type{<:DEIntegrator}) = Base.SizeUnknown()
 
 ### Other Iterators

--- a/src/integrator_interface.jl
+++ b/src/integrator_interface.jl
@@ -435,7 +435,7 @@ function Base.iterate(tup::IntegratorIntervals,state=0)
   return (tup.integrator.uprev,tup.integrator.tprev,tup.integrator.u,tup.integrator.t),state
 end
 
-Base.IteratorSize(::Type{IntegratorIntervals{T}}) where T<:DEIntegrator = Base.SizeUnknown()
+Base.IteratorSize(::Type{<:IntegratorIntervals}) = Base.SizeUnknown()
 
 intervals(integrator::DEIntegrator) = IntegratorIntervals(integrator)
 

--- a/test/integrator_tests.jl
+++ b/test/integrator_tests.jl
@@ -4,13 +4,16 @@ mutable struct DummySolution
 end
 
 mutable struct DummyIntegrator{Alg, IIP, U, T} <: DiffEqBase.DEIntegrator{Alg, IIP, U, T}
-  t
-  dt
+  uprev::U
+  tprev::T
+  u::U
+  t::T
+  dt::T
   tdir
   tstops
-  sol
+  sol::DummySolution
 
-  DummyIntegrator() = new{Bool,Bool,Bool,Bool}(0,1,1,[],DummySolution(:Default))
+  DummyIntegrator() = new{Bool,Bool,Vector{Float64},Float64}([0.0],0,[0.0],0,1,1,[],DummySolution(:Default))
 end
 
 function DiffEqBase.add_tstop!(integrator::DummyIntegrator,t)
@@ -23,6 +26,9 @@ function DiffEqBase.step!(integrator::DummyIntegrator)
   if ! isempty(integrator.tstops) && integrator.tstops[1] < t_next
     t_next = integrator.tstops[1]
   end
+  integrator.uprev .= integrator.u
+  integrator.u[1] += 2 * (t_next - integrator.t)
+  integrator.tprev = integrator.t
   integrator.t = t_next
 end
 
@@ -32,7 +38,22 @@ function step_dt!(integrator, args...)
   integrator.t - t
 end
 
+function DiffEqBase.done(integrator::DummyIntegrator)
+  integrator.t > 10
+end
+
 integrator = DummyIntegrator()
 @test step_dt!(integrator, 1.5) == 2
 @test step_dt!(integrator, 1.5, true) == 1.5
 @test_throws ErrorException step!(integrator, -1)
+
+for (u, t) in tuples(DummyIntegrator())
+  @test u[1] == 2*t
+end
+@test eltype(collect(tuples(DummyIntegrator()))) == Tuple{Vector{Float64},Float64}
+
+for (uprev, tprev, u, t) in intervals(DummyIntegrator())
+  @test u[1] - uprev[1] == 2
+  @test t - tprev == 1
+end
+@test eltype(collect(intervals(DummyIntegrator()))) == Tuple{Vector{Float64},Float64,Vector{Float64},Float64}


### PR DESCRIPTION
By default these implementations return `Base.SizeUnknown()` since in general we do not know in advance how many steps there will be before an iterator finishes.

Without these new implementations a call to `Base.collect` e.g. on `IntegratorTuples` fails with `ERROR: MethodError: no method matching length` since by default `collect` assumes that all iterators implement `length` (see https://docs.julialang.org/en/v1/manual/interfaces/#man-interface-iteration ).