### PR TITLE
Make linear iterative solver more robust

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.53.3"
+version = "6.53.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -38,7 +38,7 @@ ChainRulesCore = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
 DataStructures = "0.18"
 DocStringExtensions = "0.8"
 FunctionWrappers = "1.0"
-IterativeSolvers = "0.8, 0.9"
+IterativeSolvers = "0.9"
 IteratorInterfaceExtensions = "^0.1, ^1"
 LabelledArrays = "1.1"
 MuladdMacro = "0.2.1"


### PR DESCRIPTION
Fix https://github.com/SciML/OrdinaryDiffEq.jl/issues/1316

I will post a change to disable the non-adaptive forwarding on the OrdinaryDiffEq side later.