### PR TITLE
ignore adjoints on Discrete?

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -235,7 +235,14 @@ end
 
 struct SensitivityADPassThrough <: DiffEqBase.DEAlgorithm end
 
-ZygoteRules.@adjoint function solve_up(prob,sensealg::Union{Nothing,AbstractSensitivityAlgorithm},
+ZygoteRules.@adjoint function solve_up(prob::Union{ODEProblem,
+                                                   SteadyStateProblem,
+                                                   SDEProblem,
+                                                   DDEProblem,
+                                                   DAEProblem,
+                                                   RODEProblem,
+                                                   SDDEProblem},
+                                       sensealg::Union{Nothing,AbstractSensitivityAlgorithm},
                                        u0,p,args...;
                                        kwargs...)
   _solve_adjoint(prob,sensealg,u0,p,args...;kwargs...)
@@ -248,7 +255,13 @@ function ChainRulesCore.frule(::typeof(solve_up),prob,
   _solve_forward(prob,sensealg,u0,p,args...;kwargs...)
 end
 
-function ChainRulesCore.rrule(::typeof(solve_up),prob,
+function ChainRulesCore.rrule(::typeof(solve_up),prob::Union{ODEProblem,
+                                                   SteadyStateProblem,
+                                                   SDEProblem,
+                                                   DDEProblem,
+                                                   DAEProblem,
+                                                   RODEProblem,
+                                                   SDDEProblem},
                               sensealg::Union{Nothing,AbstractSensitivityAlgorithm},
                               u0,p,args...;
                               kwargs...)


### PR DESCRIPTION
```julia
using OrdinaryDiffEq, DiffEqFlux, Flux, DiffEqSensitivity

function loss1(p)
  f(x,p,t) = 1
  prob = DiscreteProblem(f, 0, (1,10), p)
  sol = solve(prob, FunctionMap(scale_by_time = true), saveat=[1,2,3])
  return sum(sol)
end
DiffEqFlux.sciml_train(loss1,[1],ADAM(0.05),maxiters = 20
)
```

This is a type error in the forward pass, without any DiffEq adjoints. Of all of the behaviors, this is not the one I expected lol.

```julia
MethodError: Cannot `convert` an object of type Array{Int64,1} to an object of type Int64
Closest candidates are:
  convert(::Type{T}, !Matched::ArrayInterface.StaticInt{N}) where {T<:Number, N} at C:\Users\accou\.julia\packages\ArrayInterface\Rm1rd\src\static.jl:22
  convert(::Type{R}, !Matched::T) where {R<:Real, T<:ReverseDiff.TrackedReal} at C:\Users\accou\.julia\packages\ReverseDiff\vScHI\src\tracked.jl:255
  convert(::Type{T}, !Matched::T) where T<:Number at number.jl:6
  ...
setindex!(::Array{Int64,1}, ::Array{Int64,1}, ::Int64) at array.jl:847
adjoint at array.jl:57 [inlined]
_pullback at adjoint.jl:57 [inlined]
percolate_down! at arrays_as_heaps.jl:28 [inlined]
_pullback(::Zygote.Context, ::typeof(DataStructures.percolate_down!), ::Array{Int64,1}, ::Int64, ::Array{Int64,1}, ::Base.Order.ForwardOrdering, ::Int64) at interface2.jl:0
percolate_down! at arrays_as_heaps.jl:18 [inlined]
_pullback(::Zygote.Context, ::typeof(DataStructures.percolate_down!), ::Array{Int64,1}, ::Int64, ::Array{Int64,1}, ::Base.Order.ForwardOrdering) at interface2.jl:0
heappop! at arrays_as_heaps.jl:59 [inlined]
pop! at binary_heap.jl:109 [inlined]
pop_tstop! at integrator_utils.jl:396 [inlined]
handle_tstop! at integrator_utils.jl:353 [inlined]
_pullback(::Zygote.Context, ::typeof(OrdinaryDiffEq.handle_tstop!), ::OrdinaryDiffEq.ODEIntegrator{FunctionMap{true},false,Int64,Nothing,Int64,Array{Int64,1},Float64,Int64,Int64,Array{Int64,1},ODESolution{Int64,1,Array{Int64,1},Nothing,Nothing,Array{Int64,1},Array{Array{Int64,1},1},DiscreteProblem{Int64,Tuple{Int64,Int64},false,Array{Int64,1},DiscreteFunction{false,var"#f#7",Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}},FunctionMap{true},OrdinaryDiffEq.InterpolationData{DiscreteFunction{false,var"#f#7",Nothing,Nothing},Array{Int64,1},Array{Int64,1},Array{Array{Int64,1},1},OrdinaryDiffEq.FunctionMapConstantCache},DiffEqBase.DEStats},DiscreteFunction{false,var"#f#7",Nothing,Nothing},OrdinaryDiffEq.FunctionMapConstantCache,OrdinaryDiffEq.DEOptions{Bool,Bool,Int64,Int64,typeof(DiffEqBase.ODE_DEFAULT_NORM),typeof(LinearAlgebra.opnorm),CallbackSet{Tuple{},Tuple{}},typeof(DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN),typeof(DiffEqBase.ODE_DEFAULT_PROG_MESSAGE),typeof(DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK),DataStructures.BinaryHeap{Int64,Base.Order.ForwardOrdering},DataStructures.BinaryHeap{Int64,Base.Order.ForwardOrdering},Nothing,Nothing,Int64,Tuple{},Array{Int64,1},Tuple{}},Int64,Bool,Nothing,OrdinaryDiffEq.DefaultInit}) at interface2.jl:0
solve! at solve.jl:453 [inlined]
_pullback(::Zygote.Context, ::typeof(solve!), ::OrdinaryDiffEq.ODEIntegrator{FunctionMap{true},false,Int64,Nothing,Int64,Array{Int64,1},Float64,Int64,Int64,Array{Int64,1},ODESolution{Int64,1,Array{Int64,1},Nothing,Nothing,Array{Int64,1},Array{Array{Int64,1},1},DiscreteProblem{Int64,Tuple{Int64,Int64},false,Array{Int64,1},DiscreteFunction{false,var"#f#7",Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}},FunctionMap{true},OrdinaryDiffEq.InterpolationData{DiscreteFunction{false,var"#f#7",Nothing,Nothing},Array{Int64,1},Array{Int64,1},Array{Array{Int64,1},1},OrdinaryDiffEq.FunctionMapConstantCache},DiffEqBase.DEStats},DiscreteFunction{false,var"#f#7",Nothing,Nothing},OrdinaryDiffEq.FunctionMapConstantCache,OrdinaryDiffEq.DEOptions{Bool,Bool,Int64,Int64,typeof(DiffEqBase.ODE_DEFAULT_NORM),typeof(LinearAlgebra.opnorm),CallbackSet{Tuple{},Tuple{}},typeof(DiffEqBase.ODE_DEFAULT_ISOUTOFDOMAIN),typeof(DiffEqBase.ODE_DEFAULT_PROG_MESSAGE),typeof(DiffEqBase.ODE_DEFAULT_UNSTABLE_CHECK),DataStructures.BinaryHeap{Int64,Base.Order.ForwardOrdering},DataStructures.BinaryHeap{Int64,Base.Order.ForwardOrdering},Nothing,Nothing,Int64,Tuple{},Array{Int64,1},Tuple{}},Int64,Bool,Nothing,OrdinaryDiffEq.DefaultInit}) at interface2.jl:0
#__solve#398 at solve.jl:5 [inlined]
_pullback(::Zygote.Context, ::OrdinaryDiffEq.var"##__solve#398", ::Base.Iterators.Pairs{Symbol,Array{Int64,1},Tuple{Symbol},NamedTuple{(:saveat,),Tuple{Array{Int64,1}}}}, ::typeof(DiffEqBase.__solve), ::DiscreteProblem{Int64,Tuple{Int64,Int64},false,Array{Int64,1},DiscreteFunction{false,var"#f#7",Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}}, ::FunctionMap{true}) at interface2.jl:0
adjoint at lib.jl:188 [inlined]
_pullback at adjoint.jl:57 [inlined]
__solve at solve.jl:4 [inlined]
adjoint at lib.jl:188 [inlined]
_pullback at adjoint.jl:57 [inlined]
#solve_call#447 at solve.jl:65 [inlined]
_pullback(::Zygote.Context, ::DiffEqBase.var"##solve_call#447", ::Bool, ::Base.Iterators.Pairs{Symbol,Array{Int64,1},Tuple{Symbol},NamedTuple{(:saveat,),Tuple{Array{Int64,1}}}}, ::typeof(DiffEqBase.solve_call), ::DiscreteProblem{Int64,Tuple{Int64,Int64},false,Array{Int64,1},DiscreteFunction{false,var"#f#7",Nothing,Nothing},Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}}, ::FunctionMap{true}) at interface2.jl:0
adjoint at lib.jl:188 [inlined]
_pullback at adjoint.jl...
```