### PR TITLE
AD on callback directionality?

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -58,9 +58,9 @@ Contains a single callback whose `condition` is a continuous function. The callb
   negative). For more information on what can
   be done, see the [Integrator Interface](@ref integrator) manual page. Modifications to
   `u` are safe in this function.
-- `rootfind=LeftRootFind`: This is a flag to specify the type of rootfinding to do for finding 
+- `rootfind=LeftRootFind`: This is a flag to specify the type of rootfinding to do for finding
   event location. If this is set to `LeftRootfind`, the solution will be backtracked to the point where
-  `condition==0` and if the solution isn't exact, the left limit of root is used. If set to 
+  `condition==0` and if the solution isn't exact, the left limit of root is used. If set to
   `RightRootFind`, the solution would be set to the right limit of the root. Otherwise the systems and
   the `affect!` will occur at `t+dt`.
 - `interp_points=10`: The number of interpolated points to check the condition. The
@@ -418,28 +418,28 @@ function get_condition(integrator::DEIntegrator, callback, abst)
     else
       tmp = @view integrator.u[callback.idxs]
     end
-  elseif abst == integrator.tprev
-    if callback.idxs === nothing
-      tmp = integrator.uprev
-    elseif callback.idxs isa Number
-      tmp = integrator.uprev[callback.idxs]
-    else
-      tmp = @view integrator.uprev[callback.idxs]
-    end
+  #elseif abst == integrator.tprev
+  #  if callback.idxs === nothing
+  #    tmp = integrator.uprev
+  #  elseif callback.idxs isa Number
+  #    tmp = integrator.uprev[callback.idxs]
+  #  else
+  #    tmp = @view integrator.uprev[callback.idxs]
+  #  end
   else
-    if ismutable
-      if callback.idxs === nothing
-        integrator(tmp,abst,Val{0})
-      else
-        integrator(tmp,abst,Val{0},idxs=callback.idxs)
-      end
-    else
+  #  if ismutable
+  #    if callback.idxs === nothing
+  #      integrator(tmp,abst,Val{0})
+  #    else
+  #      integrator(tmp,abst,Val{0},idxs=callback.idxs)
+  #    end
+  #  else
       if callback.idxs === nothing
         tmp = integrator(abst,Val{0})
       else
         tmp = integrator(abst,Val{0},idxs=callback.idxs)
       end
-    end
+  #  end
     # ismutable && !(callback.idxs isa Number) ? integrator(tmp,abst,Val{0},idxs=callback.idxs) :
     #                                                 tmp = integrator(abst,Val{0},idxs=callback.idxs)
   end
@@ -599,12 +599,14 @@ end
     abst = integrator.tprev+integrator.tdir*max(abs(integrator.dt/10000),100*eps(integrator.t))
     tmp_condition = get_condition(integrator, callback, abst)
 
+    prev_sign = Main.ForwardDiff.derivative(t -> get_condition(integrator, callback, t),integrator.tprev)
+
     # Sometimes users may "switch off" the condition after crossing
     # This is necessary to ensure proper non-detection of a root
     # == is for exact floating point equality!
-    prev_sign =    tmp_condition > previous_condition ? 1.0 :
-                  (tmp_condition == previous_condition ?
-                  (prev_sign = sign(previous_condition)) : -1.0)
+    #prev_sign =    tmp_condition > previous_condition ? 1.0 :
+    #              (tmp_condition == previous_condition ?
+    #              (prev_sign = sign(previous_condition)) : -1.0)
   else
     prev_sign = sign(previous_condition)
   end


### PR DESCRIPTION
Gets one more bounce out of:

```julia
using Markdown
using InteractiveUtils
using ForwardDiff

# ╔═╡ 2d729750-5455-11eb-323b-85261dc4f76a
begin # define independent package environment
	import Pkg
	Pkg.activate(mktempdir())
	Pkg.add("Plots"); using Plots
	Pkg.add("DifferentialEquations"); using DifferentialEquations
end

# ╔═╡ 59df1e80-5455-11eb-2323-1b07750a4d6b
function f(du,u,p,t)
  du[1] = u[2]
  du[2] = -p
end

# ╔═╡ 68dbca00-5455-11eb-36ba-ad0f2db6b034
function condition(u,t,integrator) # Event when event_f(u,t) == 0
  u[1]
end

# ╔═╡ 6ea96280-5455-11eb-07d4-adf2ce716897
function affect!(integrator)
  println("Bounce at t = ",integrator.t)
  integrator.u[2] = -0.1*integrator.u[2]
end

# ╔═╡ 7401cb00-5455-11eb-0b6d-973b7ed34eee
cb = ContinuousCallback(condition,affect!,interp_points=10000)

# ╔═╡ 7cdd3fc0-5455-11eb-15a2-07bf5923d0f7
function sim()
	u0 = [50.0,0.0]
	tspan = (0.0,5.0)
	p = 9.8
	prob = ODEProblem(f,u0,tspan,p)
	solve(prob,Tsit5(),callback=cb,dtmax=1)
end

# ╔═╡ 2e6ff0ce-545a-11eb-3537-251e4eff7339
sol = sim()

# ╔═╡ 790adb00-5455-11eb-301c-61f7a5f0d3cf
function plotsol(tspan, title)
	p1 = plot(sol, vars=[1], tspan=tspan, 
		framestyle=:zerolines, ylabel="position", title=title)
	p2 = plot(sol, vars=[2], tspan=tspan,
		framestyle=:zerolines, ylabel="velocity")
	plot(p1,p2,layout=(2,1),link=:x, leg=false)
end

# ╔═╡ 63237f80-545b-11eb-37a5-830fefdc5c96
plotsol((0, 5), "can see first and second bounces clearly")

# ╔═╡ a830ce20-545b-11eb-3e3c-694bb6408666
plotsol((3.83,3.91), "last four bounce are in here")

# ╔═╡ bb97b18e-545b-11eb-0e1f-ebf59b70e16f
plotsol((3.895, 3.905), "last three bounces")

# ╔═╡ 596d1ea0-545c-11eb-07e3-3fcef590c7bd
plotsol((3.903, 3.905), "last two bounces")

# ╔═╡ cb3366c0-545c-11eb-2345-571ee3526ba5
plotsol((3.90415, 3.9043), "last bounce")
```

https://discourse.julialang.org/t/diffeq-tolerances-on-continuouscallbacks/53181