### PR TITLE
Add get_concrete_problem for NonlinearProblem

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -119,6 +119,12 @@ function get_concrete_problem(prob::AbstractSteadyStateProblem, isadapt; kwargs.
   remake(prob; u0 = u0)
 end
 
+function get_concrete_problem(prob::AbstractNonlinearProblem, isadapt; kwargs...)
+  u0 = get_concrete_u0(prob, isadapt, nothing, kwargs)
+  u0 = promote_u0(u0, prob.p, nothing)
+  remake(prob; u0 = u0)
+end
+
 function get_concrete_problem(prob::AbstractEnsembleProblem, isadapt; kwargs...)
   prob
 end


### PR DESCRIPTION
Add support for declaring NonlinearProblem. Otherwise, `tspan` argument was missing error was showing.
@ChrisRackauckas, please review.