### PR TITLE
Add fastmath on scalar `calculate_residuals`

### DIFF
--- a/src/calculate_residuals.jl
+++ b/src/calculate_residuals.jl
@@ -8,7 +8,7 @@ Calculate element-wise residuals
 """
 @inline @muladd function calculate_residuals(ũ::Number, u₀::Number, u₁::Number,
                                     α, ρ, internalnorm,t)
-    ũ / (α + max(internalnorm(u₀,t), internalnorm(u₁,t)) * ρ)
+    @fastmath ũ / (α + max(internalnorm(u₀,t), internalnorm(u₁,t)) * ρ)
 end
 
 @inline function calculate_residuals(ũ::Array{T}, u₀::Array{T}, u₁::Array{T}, α::T2,
@@ -34,7 +34,7 @@ Calculate element-wise residuals
 
 @inline @muladd function calculate_residuals(u₀::Number, u₁::Number,
                                     α, ρ, internalnorm,t)
-    (u₁ - u₀) / (α + max(internalnorm(u₀,t), internalnorm(u₁,t)) * ρ)
+    @fastmath (u₁ - u₀) / (α + max(internalnorm(u₀,t), internalnorm(u₁,t)) * ρ)
 end
 
 @inline function calculate_residuals(u₀::Array{T}, u₁::Array{T}, α::T2,
@@ -60,7 +60,7 @@ Return element-wise residuals
 """
 @inline @muladd function calculate_residuals(E₁::Number, E₂::Number, u₀::Number, u₁::Number,
                                              α::Real, ρ::Real, δ::Number, scalarnorm, t)
-    (δ * E₁ + E₂) / (α + max(scalarnorm(u₀,t), scalarnorm(u₁,t)) * ρ)
+    @fastmath (δ * E₁ + E₂) / (α + max(scalarnorm(u₀,t), scalarnorm(u₁,t)) * ρ)
 end
 
 @inline function calculate_residuals(E₁::Array{<:Number}, E₂::Array{<:Number},


### PR DESCRIPTION
```julia
using DiffEqBase
out, ũ, u₀, u₁ = [rand(100,100) for i in 1:4];
α, ρ, internalnorm, t = 1e-4, 1e-6, DiffEqBase.ODE_DEFAULT_NORM, 0.1;
DiffEqBase.calculate_residuals!(out, ũ, u₀, u₁, α, ρ, internalnorm, t);
using BenchmarkTools
@btime DiffEqBase.calculate_residuals!($out, $ũ, $u₀, $u₁, $α, $ρ, $internalnorm, $t);
```

gives

```julia
julia> @btime DiffEqBase.calculate_residuals!($out, $ũ, $u₀, $u₁, $α, $ρ, $internalnorm, $t); # fastmath
  11.188 μs (0 allocations: 0 bytes)

julia> @btime DiffEqBase.calculate_residuals!($out, $ũ, $u₀, $u₁, $α, $ρ, $internalnorm, $t); # master
  20.854 μs (0 allocations: 0 bytes)
```