### PR TITLE
Faster SIMD _exp2

### DIFF
--- a/src/fastpow.jl
+++ b/src/fastpow.jl
@@ -52,8 +52,8 @@ const EXP2FT = (Float32(0x1.6a09e667f3bcdp-1),
                 Float32(0x1.4bfdad5362a27p+0),
                 Float32(0x1.5ab07dd485429p+0))
 @inline function _exp2(x::Float32)
-    TBLBITS = 4
-    TBLSIZE = (1 << TBLBITS)
+    TBLBITS = UInt32(4)
+    TBLSIZE = UInt32(1 << TBLBITS)
 
     redux = Float32(0x1.8p23f) / TBLSIZE
     P1    = Float32(0x1.62e430p-1f)
@@ -64,15 +64,15 @@ const EXP2FT = (Float32(0x1.6a09e667f3bcdp-1),
     # Reduce x, computing z, i0, and k.
     t::Float32 = x + redux
     i0 = reinterpret(UInt32, t)
-    i0 += TBLSIZE ÷ 2
+    i0 += TBLSIZE ÷ UInt32(2)
     k::UInt32 = unsafe_trunc(UInt32, (i0 >> TBLBITS) << 20)
-    i0 &= TBLSIZE - 1
+    i0 &= TBLSIZE - UInt32(1)
     t -= redux
     z = x - t
     twopk = Float32(reinterpret(Float64, UInt64(0x3ff00000 + k) << 32))
 
     # Compute r = exp2(y) = exp2ft[i0] * p(z).
-    tv = EXP2FT[i0+1]
+    tv = EXP2FT[i0+UInt32(1)]
     u = tv * z
     tv = tv + u * (P1 + z * P2) + u * (z * z) * (P3 + z * P4)
 


### PR DESCRIPTION
Benchmarks, before:
```julia
julia> using FastBroadcast, DiffEqBase, BenchmarkTools

julia> x = randn(Float32, 256); y = similar(x);

julia> @benchmark @.. $y = Base.Math.exp_impl_fast($x,Val(2)) # inlined base broadcast
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     179.794 ns (0.00% GC)
  median time:      180.200 ns (0.00% GC)
  mean time:        180.345 ns (0.00% GC)
  maximum time:     230.781 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     700

julia> @benchmark @.. $y = DiffEqBase._exp2($x)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     108.322 ns (0.00% GC)
  median time:      108.691 ns (0.00% GC)
  mean time:        108.841 ns (0.00% GC)
  maximum time:     164.939 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     932
```
after:
```julia
julia> @benchmark @.. $y = DiffEqBase._exp2($x)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     84.004 ns (0.00% GC)
  median time:      84.419 ns (0.00% GC)
  mean time:        84.527 ns (0.00% GC)
  maximum time:     132.171 ns (0.00% GC)
  --------------
  samples:          10000
  evals/sample:     964
```

Accuracy:
```julia
julia> using SLEEFPirates

julia> include(joinpath(pkgdir(SLEEFPirates), "test", "testsetup.jl") # requires 0.6.17

julia> T = Float32; xx = nextfloat(SLEEFPirates.VectorizationBase.MIN_EXP(Val(2),T)):T(0.02):prevfloat(SLEEFPirates.VectorizationBase.MAX_EXP(Val(2),T));

julia> test_function_acc(Float32, x -> Base.Math.exp_impl(x,Val(2)), exp2, xx, 10, false, 15)
#32               : max 0.6063165664672852 at x = -1.4999951                      : mean 0.23073441444655998

julia> test_function_acc(Float32, x -> DiffEqBase._exp2(x), exp2, xx, 10, false, 15)
#34               : max 1.344230055809021 at x = 127.04                          : mean 0.34935614371463275
```
There were error messages I cleaned up resulting from neither supporting `VectorizationBase.Vec` inputs.

Maximum error was 0.6 and 1.34 units in last place.
I think @YingboMa should make a PR to Base Julia to implement a faster `exp2_fast`.

The performance improvement from this PR comes from using 32 bit integers as indices. Because it is loading 32 bit floats from the table, using 32 bit indices means it can load all the floats with a single gather, rather than requiring two gathers (due to only being able to fit half the indices into a SIMD register) and combining the results afterwards.