### PR TITLE
Fix ODE_DEFAULT_NORM for empty arrays (fixes #664)

### DIFF
--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -1,6 +1,7 @@
 @inline UNITLESS_ABS2(x::Number) = abs2(x)
 @inline UNITLESS_ABS2(x::AbstractArray) = sum(UNITLESS_ABS2, x)
 @inline UNITLESS_ABS2(x::RecursiveArrayTools.ArrayPartition) = sum(UNITLESS_ABS2, x.x)
+Base.mapreduce_empty(::typeof(UNITLESS_ABS2), op, T) = abs2(Base.reduce_empty(op, T))
 
 @inline recursive_length(u::AbstractArray{<:Number}) = length(u)
 @inline recursive_length(u::Number) = length(u)

--- a/test/ode_default_norm.jl
+++ b/test/ode_default_norm.jl
@@ -39,3 +39,8 @@ u6 = ArrayPartition(1.0,1.0)
 @test UNITLESS_ABS2(u6) == 2.0
 @test recursive_length(u6) == 2
 @test ODE_DEFAULT_NORM(u6, 0.0) == 1.0
+
+u7 = ArrayPartition(u1, ones(0))
+@test UNITLESS_ABS2(u7) == 3.0
+@test recursive_length(u7) == 3
+@test ODE_DEFAULT_NORM(u7, 0.0) == 1.0


### PR DESCRIPTION
I’ve added the change proposed in #664 plus a test that fails without that fix. The `mapreduce_empty` implementation mirrors [what is done for `abs2` in `Base`](https://github.com/JuliaLang/julia/blob/6aaedecc447e3d8226d5027fb13d0c3cbfbfea2a/base/reduce.jl#L345).