### PR TITLE
Add asymmetric fastpow overloads

### DIFF
--- a/src/init.jl
+++ b/src/init.jl
@@ -51,6 +51,8 @@ function __init__()
     value(x::ForwardDiff.Dual) = value(ForwardDiff.value(x))
 
     @inline fastpow(x::ForwardDiff.Dual, y::ForwardDiff.Dual) = x^y
+    @inline fastpow(x::ForwardDiff.Dual, y::Real) = x^y
+    @inline fastpow(x::Real, y::ForwardDiff.Dual) = x^y
 
     sse(x::Number) = x^2
     sse(x::ForwardDiff.Dual) = sse(ForwardDiff.value(x)) + sum(sse, ForwardDiff.partials(x))
@@ -109,6 +111,8 @@ function __init__()
     value(x::Measurements.Measurement) = Measurements.value(x)
 
     @inline fastpow(x::Measurements.Measurement, y::Measurements.Measurement) = x^y
+    @inline fastpow(x::Measurements.Measurement, y::Real) = x^y
+    @inline fastpow(x::Real, y::Measurements.Measurement) = x^y
 
     # Support adaptive steps should be errorless
     @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:Measurements.Measurement,N},t) where {N}
@@ -129,6 +133,8 @@ function __init__()
     value(x::MonteCarloMeasurements.AbstractParticles) = mean(x)
 
     @inline fastpow(x::MonteCarloMeasurements.AbstractParticles, y::MonteCarloMeasurements.AbstractParticles) = x^y
+    @inline fastpow(x::MonteCarloMeasurements.AbstractParticles, y::Real) = x^y
+    @inline fastpow(x::Real, y::MonteCarloMeasurements.AbstractParticles) = x^y
 
     # Support adaptive steps should be errorless
     @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:MonteCarloMeasurements.AbstractParticles,N},t) where {N}

--- a/src/reversediff.jl
+++ b/src/reversediff.jl
@@ -8,6 +8,10 @@ promote_u0(u0::AbstractArray{<:ReverseDiff.TrackedReal},p::AbstractArray{<:Rever
 promote_u0(u0,p::ReverseDiff.TrackedArray,t0) = ReverseDiff.track(u0)
 promote_u0(u0,p::AbstractArray{<:ReverseDiff.TrackedReal},t0) = eltype(p).(u0)
 
+@inline fastpow(x::ReverseDiff.TrackedReal, y::ReverseDiff.TrackedReal) = x^y
+@inline fastpow(x::ReverseDiff.TrackedReal, y::Real) = x^y
+@inline fastpow(x::Real, y::ReverseDiff.TrackedReal) = x^y
+
 # Support adaptive with non-tracked time
 @inline function ODE_DEFAULT_NORM(u::ReverseDiff.TrackedArray,t) where {N}
   sqrt(sum(abs2,value(u)) / length(u))

--- a/src/tracker.jl
+++ b/src/tracker.jl
@@ -12,6 +12,9 @@ promote_u0(u0,p::AbstractArray{<:Tracker.TrackedReal},t0) = eltype(p).(u0)
 
 
 @inline fastpow(x::Tracker.TrackedReal, y::Tracker.TrackedReal) = x^y
+@inline fastpow(x::Tracker.TrackedReal, y::Real) = x^y
+@inline fastpow(x::Real, y::Tracker.TrackedReal) = x^y
+
 @inline Base.any(f::Function,x::Tracker.TrackedArray) = any(f,Tracker.data(x))
 
 # Support adaptive with non-tracked time


### PR DESCRIPTION
Technically not needed for anything, but noticed while debugging https://github.com/SciML/OrdinaryDiffEq.jl/issues/1414 as potentially useful.