### PR TITLE
Use a nudge factor to remove repeats

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -528,7 +528,7 @@ end
     abst = integrator.tprev+integrator.dt * callback.repeat_nudge
     tmp_condition = get_condition(integrator, callback, abst)
     @. prev_sign = sign(previous_condition)
-    prev_sign[ivec] = tmp_condition[ivec]
+    prev_sign[ivec] = sign(tmp_condition[ivec])
   else
       @. prev_sign = sign(previous_condition)
   end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -528,7 +528,7 @@ end
     abst = integrator.tprev+integrator.tdir*integrator.dt * callback.repeat_nudge
     tmp_condition = get_condition(integrator, callback, abst)
     @. prev_sign = sign(previous_condition)
-    prev_sign[ivec] .= tmp_condition[ivec]
+    prev_sign[ivec] = tmp_condition[ivec]
   else
       @. prev_sign = sign(previous_condition)
   end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -525,7 +525,7 @@ end
     end
 
     # Evaluate condition slightly in future
-    abst = integrator.tprev+integrator.tdir*integrator.dt * callback.repeat_nudge
+    abst = integrator.tprev+integrator.dt * callback.repeat_nudge
     tmp_condition = get_condition(integrator, callback, abst)
     @. prev_sign = sign(previous_condition)
     prev_sign[ivec] = tmp_condition[ivec]
@@ -597,7 +597,7 @@ end
     end
 
     # Evaluate condition slightly in future
-    abst = integrator.tprev+integrator.tdir*integrator.dt * callback.repeat_nudge
+    abst = integrator.tprev+integrator.dt * callback.repeat_nudge
     tmp_condition = get_condition(integrator, callback, abst)
     prev_sign = sign(tmp_condition)
   else
@@ -671,7 +671,7 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
             # Determined that there is an event by derivative
             # But floating point error may make the end point negative
 
-            bottom_t += integrator.tdir*integrator.dt * callback.repeat_nudge
+            bottom_t += integrator.dt * callback.repeat_nudge
             sign_top = sign(zero_func(top_t))
             sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) && error("Double callback crossing floating pointer reducer errored. Report this issue.")
           end
@@ -731,7 +731,7 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
               # Determined that there is an event by derivative
               # But floating point error may make the end point negative
 
-              bottom_t += integrator.tdir*integrator.dt * callback.repeat_nudge
+              bottom_t += integrator.dt * callback.repeat_nudge
               sign_top = sign(zero_func(top_t))
               sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) && error("Double callback crossing floating pointer reducer errored. Report this issue.")
             end

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -673,7 +673,7 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
 
             bottom_t += integrator.tdir*integrator.dt * callback.repeat_nudge
             sign_top = sign(zero_func(top_t))
-            sign(zero_func(bottom_t)) * zero_func(bottom_t) >= zero(sign_top) && error("Double callback crossing floating pointer reducer errored. Report this issue.")
+            sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) && error("Double callback crossing floating pointer reducer errored. Report this issue.")
           end
           Θ = bisection(zero_func, (bottom_t, top_t), isone(integrator.tdir), callback.rootfind, callback.abstol, callback.reltol)
           integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ), Θ)
@@ -733,7 +733,7 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
 
               bottom_t += integrator.tdir*integrator.dt * callback.repeat_nudge
               sign_top = sign(zero_func(top_t))
-              sign(zero_func(bottom_t)) * zero_func(bottom_t) >= zero(sign_top) && error("Double callback crossing floating pointer reducer errored. Report this issue.")
+              sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) && error("Double callback crossing floating pointer reducer errored. Report this issue.")
             end
             Θ = bisection(zero_func, (bottom_t, top_t), isone(integrator.tdir), callback.rootfind, callback.abstol, callback.reltol)
             if integrator.tdir * Θ < integrator.tdir * min_t

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -22,7 +22,7 @@ ContinuousCallback(condition,affect!,affect_neg!;
                    rootfind=LeftRootFind,
                    save_positions=(true,true),
                    interp_points=10,
-                   abstol=10eps(),reltol=0)
+                   abstol=10eps(),reltol=0,repeat_nudge=1//100)
 ```
 
 ```julia
@@ -34,7 +34,7 @@ function ContinuousCallback(condition,affect!;
                    save_positions=(true,true),
                    affect_neg! = affect!,
                    interp_points=10,
-                   abstol=10eps(),reltol=0)
+                   abstol=10eps(),reltol=0,repeat_nudge=1//100)
 ```
 
 Contains a single callback whose `condition` is a continuous function. The callback is triggered when this function evaluates to 0.
@@ -86,8 +86,11 @@ Contains a single callback whose `condition` is a continuous function. The callb
 - `abstol=1e-14` & `reltol=0`: These are used to specify a tolerance from zero for the rootfinder:
   if the starting condition is less than the tolerance from zero, then no root will be detected.
   This is to stop repeat events happening just after a previously rootfound event.
+- `repeat_nudge = 1//100`: This is used to set the next testing point after a
+  previously found zero. Defaults to 1//100, which means after a callback the next
+  sign check will take place at t + dt*1//100 instead of at t to avoid repeats.
 """
-struct ContinuousCallback{F1,F2,F3,F4,F5,T,T2,I,R} <: AbstractContinuousCallback
+struct ContinuousCallback{F1,F2,F3,F4,F5,T,T2,T3,I,R} <: AbstractContinuousCallback
   condition::F1
   affect!::F2
   affect_neg!::F3
@@ -100,14 +103,16 @@ struct ContinuousCallback{F1,F2,F3,F4,F5,T,T2,I,R} <: AbstractContinuousCallback
   dtrelax::R
   abstol::T
   reltol::T2
+  repeat_nudge::T3
   ContinuousCallback(condition::F1,affect!::F2,affect_neg!::F3,
                      initialize::F4,finalize::F5,idxs::I,rootfind,
-                     interp_points,save_positions,dtrelax::R,abstol::T,reltol::T2) where {F1,F2,F3,F4,F5,T,T2,I,R} =
-                       new{F1,F2,F3,F4,F5,T,T2,I,R}(condition,
+                     interp_points,save_positions,dtrelax::R,abstol::T,reltol::T2,
+                     repeat_nudge::T3) where {F1,F2,F3,F4,F5,T,T2,T3,I,R} =
+                       new{F1,F2,F3,F4,F5,T,T2,T3,I,R}(condition,
                                                affect!,affect_neg!,
                                                initialize,finalize,idxs,rootfind,interp_points,
                                                BitArray(collect(save_positions)),
-                                               dtrelax,abstol,reltol)
+                                               dtrelax,abstol,reltol,repeat_nudge)
 end
 
 ContinuousCallback(condition,affect!,affect_neg!;
@@ -118,12 +123,13 @@ ContinuousCallback(condition,affect!,affect_neg!;
                    save_positions=(true,true),
                    interp_points=10,
                    dtrelax=1,
-                   abstol=10eps(),reltol=0) = ContinuousCallback(
+                   abstol=10eps(),reltol=0,
+                   repeat_nudge = 1//100) = ContinuousCallback(
                               condition,affect!,affect_neg!,initialize,finalize,
                               idxs,
                               rootfind,interp_points,
                               save_positions,
-                              dtrelax,abstol,reltol)
+                              dtrelax,abstol,reltol,repeat_nudge)
 
 function ContinuousCallback(condition,affect!;
                    initialize = INITIALIZE_DEFAULT,
@@ -134,13 +140,13 @@ function ContinuousCallback(condition,affect!;
                    affect_neg! = affect!,
                    interp_points=10,
                    dtrelax=1,
-                   abstol=10eps(),reltol=0)
+                   abstol=10eps(),reltol=0,repeat_nudge=1//100)
 
  ContinuousCallback(
             condition,affect!,affect_neg!,initialize,finalize,idxs,
             rootfind,interp_points,
             collect(save_positions),
-            dtrelax,abstol,reltol)
+            dtrelax,abstol,reltol,repeat_nudge)
 
 end
 
@@ -153,7 +159,7 @@ VectorContinuousCallback(condition,affect!,affect_neg!,len;
                          rootfind=LeftRootFind,
                          save_positions=(true,true),
                          interp_points=10,
-                         abstol=10eps(),reltol=0)
+                         abstol=10eps(),reltol=0,repeat_nudge = 1//100)
 ```
 
 ```julia
@@ -165,7 +171,7 @@ VectorContinuousCallback(condition,affect!,len;
                    save_positions=(true,true),
                    affect_neg! = affect!,
                    interp_points=10,
-                   abstol=10eps(),reltol=0)
+                   abstol=10eps(),reltol=0,repeat_nudge=1//100)
 ```
 
 This is also a subtype of `AbstractContinuousCallback`. `CallbackSet` is not feasible when you have a large number of callbacks,
@@ -183,7 +189,7 @@ multiple events.
 
 Rest of the arguments have the same meaning as in [`ContinuousCallback`](@ref).
 """
-struct VectorContinuousCallback{F1,F2,F3,F4,F5,T,T2,I,R} <: AbstractContinuousCallback
+struct VectorContinuousCallback{F1,F2,F3,F4,F5,T,T2,T3,I,R} <: AbstractContinuousCallback
   condition::F1
   affect!::F2
   affect_neg!::F3
@@ -197,15 +203,16 @@ struct VectorContinuousCallback{F1,F2,F3,F4,F5,T,T2,I,R} <: AbstractContinuousCa
   dtrelax::R
   abstol::T
   reltol::T2
+  repeat_nudge::T3
   VectorContinuousCallback(condition::F1,affect!::F2,affect_neg!::F3,len::Int,
                            initialize::F4,finalize::F5,idxs::I,rootfind,
                            interp_points,save_positions,dtrelax::R,
-                           abstol::T,reltol::T2) where {F1,F2,F3,F4,F5,T,T2,I,R} =
-                       new{F1,F2,F3,F4,F5,T,T2,I,R}(condition,
+                           abstol::T,reltol::T2,repeat_nudge) where {F1,F2,F3,F4,F5,T,T2,T3,I,R} =
+                       new{F1,F2,F3,F4,F5,T,T2,T3,I,R}(condition,
                                                affect!,affect_neg!,len,
                                                initialize,finalize,idxs,rootfind,interp_points,
                                                BitArray(collect(save_positions)),
-                                               dtrelax,abstol,reltol)
+                                               dtrelax,abstol,reltol,repeat_nudge)
 end
 
 VectorContinuousCallback(condition,affect!,affect_neg!,len;
@@ -216,13 +223,13 @@ VectorContinuousCallback(condition,affect!,affect_neg!,len;
                          save_positions=(true,true),
                          interp_points=10,
                          dtrelax=1,
-                         abstol=10eps(),reltol=0) = VectorContinuousCallback(
+                         abstol=10eps(),reltol=0,repeat_nudge=1//100) = VectorContinuousCallback(
                               condition,affect!,affect_neg!,len,
                               initialize,finalize,
                               idxs,
                               rootfind,interp_points,
                               save_positions,dtrelax,
-                              abstol,reltol)
+                              abstol,reltol,repeat_nudge)
 
 function VectorContinuousCallback(condition,affect!,len;
                    initialize = INITIALIZE_DEFAULT,
@@ -233,13 +240,13 @@ function VectorContinuousCallback(condition,affect!,len;
                    affect_neg! = affect!,
                    interp_points=10,
                    dtrelax=1,
-                   abstol=10eps(),reltol=0)
+                   abstol=10eps(),reltol=0,repeat_nudge=1//100)
 
  VectorContinuousCallback(
             condition,affect!,affect_neg!,len,initialize,finalize,idxs,
             rootfind,interp_points,
             collect(save_positions),
-            dtrelax,abstol,reltol)
+            dtrelax,abstol,reltol,repeat_nudge)
 
 end
 
@@ -518,20 +525,10 @@ end
     end
 
     # Evaluate condition slightly in future
-    if integrator.t == 0
-      abst = integrator.tprev+integrator.tdir*abs(integrator.dt/10000)
-    else
-      abst = integrator.tprev+integrator.tdir*100*eps(integrator.t)
-    end
+    abst = integrator.tprev+integrator.tdir*integrator.dt * callback.repeat_nudge
     tmp_condition = get_condition(integrator, callback, abst)
-
-    # Sometimes users may "switch off" the condition after crossing
-    # This is necessary to ensure proper non-detection of a root
-    # == is for exact floating point equality!
     @. prev_sign = sign(previous_condition)
-    prev_sign[ivec] = tmp_condition[ivec] > previous_condition[ivec] ? 1.0 :
-                  (tmp_condition[ivec] == previous_condition[ivec] ?
-                  (prev_sign[ivec] = sign(previous_condition[ivec])) : -1.0)
+    prev_sign[ivec] .= tmp_condition[ivec]
   else
       @. prev_sign = sign(previous_condition)
   end
@@ -600,19 +597,9 @@ end
     end
 
     # Evaluate condition slightly in future
-    if integrator.t == 0
-      abst = integrator.tprev+integrator.tdir*abs(integrator.dt/10000)
-    else
-      abst = integrator.tprev+integrator.tdir*100*eps(integrator.t)
-    end
+    abst = integrator.tprev+integrator.tdir*integrator.dt * callback.repeat_nudge
     tmp_condition = get_condition(integrator, callback, abst)
-
-    # Sometimes users may "switch off" the condition after crossing
-    # This is necessary to ensure proper non-detection of a root
-    # == is for exact floating point equality!
-    prev_sign =    tmp_condition > previous_condition ? 1.0 :
-                  (tmp_condition == previous_condition ?
-                  (prev_sign = sign(previous_condition)) : -1.0)
+    prev_sign = sign(tmp_condition)
   else
     prev_sign = sign(previous_condition)
   end
@@ -684,17 +671,9 @@ function find_callback_time(integrator,callback::ContinuousCallback,counter)
             # Determined that there is an event by derivative
             # But floating point error may make the end point negative
 
+            bottom_t += integrator.tdir*integrator.dt * callback.repeat_nudge
             sign_top = sign(zero_func(top_t))
-            diff_t = integrator.tdir*2eps(bottom_t)
-            bottom_t += diff_t
-            iter = 1
-            # This check should match the same check in bisection
-            while sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) && iter < 12
-              diff_t *= 5
-              bottom_t = integrator.tprev + diff_t
-              iter += 1
-            end
-            iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
+            sign(zero_func(bottom_t)) * zero_func(bottom_t) >= zero(sign_top) && error("Double callback crossing floating pointer reducer errored. Report this issue.")
           end
           Θ = bisection(zero_func, (bottom_t, top_t), isone(integrator.tdir), callback.rootfind, callback.abstol, callback.reltol)
           integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ), Θ)
@@ -752,17 +731,9 @@ function find_callback_time(integrator,callback::VectorContinuousCallback,counte
               # Determined that there is an event by derivative
               # But floating point error may make the end point negative
 
+              bottom_t += integrator.tdir*integrator.dt * callback.repeat_nudge
               sign_top = sign(zero_func(top_t))
-              diff_t = integrator.tdir * 2eps(bottom_t)
-              bottom_t += diff_t
-              iter = 1
-              # This check should match the same check in bisection
-              while sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) && iter < 12
-                diff_t *= 5
-                bottom_t = integrator.tprev + diff_t
-                iter += 1
-              end
-              iter == 12 && error("Double callback crossing floating pointer reducer errored. Report this issue.")
+              sign(zero_func(bottom_t)) * zero_func(bottom_t) >= zero(sign_top) && error("Double callback crossing floating pointer reducer errored. Report this issue.")
             end
             Θ = bisection(zero_func, (bottom_t, top_t), isone(integrator.tdir), callback.rootfind, callback.abstol, callback.reltol)
             if integrator.tdir * Θ < integrator.tdir * min_t

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -207,7 +207,7 @@ struct VectorContinuousCallback{F1,F2,F3,F4,F5,T,T2,T3,I,R} <: AbstractContinuou
   VectorContinuousCallback(condition::F1,affect!::F2,affect_neg!::F3,len::Int,
                            initialize::F4,finalize::F5,idxs::I,rootfind,
                            interp_points,save_positions,dtrelax::R,
-                           abstol::T,reltol::T2,repeat_nudge) where {F1,F2,F3,F4,F5,T,T2,T3,I,R} =
+                           abstol::T,reltol::T2,repeat_nudge::T3) where {F1,F2,F3,F4,F5,T,T2,T3,I,R} =
                        new{F1,F2,F3,F4,F5,T,T2,T3,I,R}(condition,
                                                affect!,affect_neg!,len,
                                                initialize,finalize,idxs,rootfind,interp_points,

--- a/test/downstream/event_detection_tests.jl
+++ b/test/downstream/event_detection_tests.jl
@@ -1,5 +1,6 @@
 using StaticArrays
 using OrdinaryDiffEq
+using LinearAlgebra
 using Test
 
 @inbounds @inline function ż(z, p, t)
@@ -104,7 +105,7 @@ f! = function (du,u,p,t)
   du[2] = -p
 end
 
-function condition!(out,u,t,integrator) 
+function condition!(out,u,t,integrator)
   out[1] = u[1]
   out[2] = u[2]
 end
@@ -127,3 +128,85 @@ begin
     sol = solve(prob,Tsit5(), callback=Vcb)
 end
 
+
+"""
+    eoms(u, p, t)
+
+Equations of motion for the system (6-Dimensional).
+"""
+function eoms(u, p, t)
+    mu = p
+    omm = 1 - mu
+
+    r13 = sqrt((u[1] + mu)^2 + u[2]^2 + u[3]^2)
+    r13_3 = r13^3
+    r23 = sqrt((u[1] - 1 + mu)^2 + u[2]^2 + u[3]^2)
+    r23_3 = r23^3
+
+    Ωx = u[1] - (omm) * (u[1] + mu) / r13_3 - mu * (u[1] - omm) / r23_3
+    Ωy = u[2] - (omm) * u[2] / r13_3 - mu * u[2] / r23_3
+    Ωz = -(omm) * u[3] / r13_3 - mu * u[3] / r23_3
+
+    return @SVector [
+        u[4],
+        u[5],
+        u[6],
+        2u[5] + Ωx,
+        -2u[4] + Ωy,
+        Ωz
+    ]
+end
+
+"""
+    distance(sol, q, t)
+
+Calculate the isochronous position variation between `q` and `sol(t)`.
+"""
+function distance(sol, q, t)
+    posinds = @SVector [1, 2, 3]
+    q_sol = sol(t)
+    return norm(q[posinds] .- q_sol[posinds])
+end
+
+"""
+    distance_callback(sol, threshold)
+
+Create a `ContinuousCallback` that terminates integration when `distance` is
+less than `threshold`.
+"""
+function distance_callback(sol, threshold)
+    condition(u, t, _) = distance(sol, u, t) - threshold
+    affect!(integrator) = nothing
+    affect_neg!(integrator) = terminate!(integrator)
+    return ContinuousCallback(condition, affect!, affect_neg!)
+end
+
+# Mu Parameter
+μ = 0.012150607114626023
+
+# State of Chief at time 0
+q_chief = @SVector [1.0220277279709828, 0.0, -0.18210117430516676, 0.0, -0.1032699633021813, 0.0]
+tof_chief = 10.0
+
+# Integrate the chief trajectory
+prob_chief = ODEProblem{false}(eoms, q_chief, (0.0, tof_chief), μ)
+sol_chief = solve(prob_chief, Vern9(); abstol=1e-12, reltol=1e-12)
+
+# Define point where deputy departs the chief
+t_dep_start = 0.012113772215335508 # Time the deputy trajectory starts at
+
+# Get state of chief at this departure point
+q_depart = sol_chief(t_dep_start)
+
+# Apply change in velocity at that point
+dv = @SVector [0.0, 0.0, 0.0, 0.00017947635829913735, -5.932764319639683e-5, -0.0009575628577891083]
+q_deputy = q_depart + dv
+
+# Build the callback
+threshold = 0.00026014568158168577
+cb = distance_callback(sol_chief, threshold)
+
+# Build & Solve the deputy problem
+tspan_deputy = (t_dep_start, tof_chief - t_dep_start)
+prob_deputy = ODEProblem{false}(eoms, q_deputy, tspan_deputy, μ)
+sol_deputy = solve(prob_deputy, Vern9(); callback=cb, abstol=1e-12, reltol=1e-12)

--- a/test/downstream/event_detection_tests.jl
+++ b/test/downstream/event_detection_tests.jl
@@ -210,3 +210,28 @@ cb = distance_callback(sol_chief, threshold)
 tspan_deputy = (t_dep_start, tof_chief - t_dep_start)
 prob_deputy = ODEProblem{false}(eoms, q_deputy, tspan_deputy, μ)
 sol_deputy = solve(prob_deputy, Vern9(); callback=cb, abstol=1e-12, reltol=1e-12)
+
+gravity = 9.8
+stiffness = 500
+equilibrium_length = 1
+T = 5.0
+
+f(u, p, t) = begin
+    x1, x2, dx1, dx2 = u
+    length = abs(x2 - x1)
+    spring_force = stiffness * (equilibrium_length - length)
+    ddx1 = -gravity - spring_force
+    if x1 <= 0
+      ddx1 = max(0, ddx1)
+    end
+    ddx2 = -gravity + spring_force
+    [dx1, dx2, ddx1, ddx2]
+end
+
+sol = solve(
+    ODEProblem(f, [5.0, 6.0, 0.0, 0.0], (0.0, T)),
+    Tsit5(),
+    callback = ContinuousCallback((u, _, _) -> u[1], (integrator) -> (integrator.u[3] = 0)),
+    reltol = 1e-2,
+    abstol = 1e-2
+)

--- a/test/downstream/event_detection_tests.jl
+++ b/test/downstream/event_detection_tests.jl
@@ -217,7 +217,7 @@ stiffness = 500
 equilibrium_length = 1
 T = 5.0
 
-f(u, p, t) = begin
+f2(u, p, t) = begin
     x1, x2, dx1, dx2 = u
     length = abs(x2 - x1)
     spring_force = stiffness * (equilibrium_length - length)
@@ -239,7 +239,7 @@ sol = solve(
 )
 
 # https://github.com/SciML/DifferentialEquations.jl/issues/601
-f(u, p, t) = return [u[2], 0]
+f2(u, p, t) = return [u[2], 0]
 prob = ODEProblem(f, [-10., 1.], (-10.0, 10.0), nothing)
 
 is_wall(u, t, integrator) = return u[1]

--- a/test/downstream/event_detection_tests.jl
+++ b/test/downstream/event_detection_tests.jl
@@ -235,3 +235,15 @@ sol = solve(
     reltol = 1e-2,
     abstol = 1e-2
 )
+
+
+f(u, p, t) = return [u[2], 0]
+prob = ODEProblem(f, [-10., 1.], (-10.0, 10.0), nothing)
+
+is_wall(u, t, integrator) = return u[1]
+affect!(integrator) = println("Wall!")
+cb = ContinuousCallback(is_wall,
+                            affect!
+                            )
+
+sol = solve(prob, Tsit5(), callback = cb)


### PR DESCRIPTION
Sometimes simple is better. Instead of using a derivative estimate, now we just check at t + dt * repeat_nudge to avoid repeated zeros, with a default to 1//100 which seems to be a nice balance between numerical stability and keeping most of the interval still an eventful zone. 

Fixes https://github.com/SciML/DifferentialEquations.jl/issues/758
Fixes SciML/DifferentialEquations.jl#647
Fixes SciML/DifferentialEquations.jl#724
Fixes SciML/DifferentialEquations.jl#601
Fixes SciML/DifferentialEquations.jl#642
Fixes https://github.com/SciML/DiffEqBase.jl/issues/599