### PR TITLE
Add new NAN_CHECK for DEDataArray

### DIFF
--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -27,7 +27,8 @@ Base.mapreduce_empty(::typeof(UNITLESS_ABS2), op, T) = abs2(Base.reduce_empty(op
 @inline NAN_CHECK(x::Enum) = false
 @inline NAN_CHECK(x::AbstractArray) = any(NAN_CHECK, x)
 @inline NAN_CHECK(x::RecursiveArrayTools.ArrayPartition) = any(NAN_CHECK, x.x)
-@inline NAN_CHECK(x::DEDataArray) = any(NAN_CHECK, x.x)
+@inline NAN_CHECK(x::DEDataArray) = NAN_CHECK(x.x)
+
 
 @inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u,p,t) = false
 @inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u::Union{Number,AbstractArray},p,t) = NAN_CHECK(u)

--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -27,6 +27,7 @@ Base.mapreduce_empty(::typeof(UNITLESS_ABS2), op, T) = abs2(Base.reduce_empty(op
 @inline NAN_CHECK(x::Enum) = false
 @inline NAN_CHECK(x::AbstractArray) = any(NAN_CHECK, x)
 @inline NAN_CHECK(x::RecursiveArrayTools.ArrayPartition) = any(NAN_CHECK, x.x)
+@inline NAN_CHECK(x::DEDataArray) = any(NAN_CHECK, x.x)
 
 @inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u,p,t) = false
 @inline ODE_DEFAULT_UNSTABLE_CHECK(dt,u::Union{Number,AbstractArray},p,t) = NAN_CHECK(u)


### PR DESCRIPTION
I was using a `DEDataArray` that contained an `ArrayPartition` with a complex and a real part in an ODEProblem. I noticed during profiling that the error checking was taking a long time. This was due to the type-unstable iteration of the `ArrayPartition`. However, by adding an extra dispatch for the NAN_CHECK it is possible to avoid this. This seems to give a good speedup without any negatives.

```julia
using DiffEqBase
using RecursiveArrayTools
using BenchmarkTools

mutable struct MyDataArray{T}  <: DEDataArray{T,1}
    x::ArrayPartition{Complex{T}, Tuple{Vector{T},Vector{Complex{T}}}}
    state::Int
end

partition = ArrayPartition(rand(10), rand(ComplexF64, 10))
data_array = MyDataArray(partition, 1)

new_NAN_CHECK(x::DiffEqBase.DEDataArray) = any(DiffEqBase.NAN_CHECK, x.x)
```

```julia
# NAN_CHECK for bare array partition
julia> @btime DiffEqBase.NAN_CHECK($partition)
	12.212 ns (0 allocations: 0 bytes)

# Current NAN_CHECK for DEDataArray, using NAN_CHECK(::AbstractArray)
julia> @btime DiffEqBase.NAN_CHECK($data_array)
	14.200 μs (119 allocations: 3.56 KiB)

# New NAN_CHECK
julia> @btime new_NAN_CHECK($data_array)
	5.800 ns (0 allocations: 0 bytes)
```
