### PR TITLE
Handle all prob.kwargs at the interface level

### DIFF
--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -62,6 +62,9 @@ ZygoteRules.@adjoint function DiffEqBase.EnsembleSolution(sim,time,converged)
     arrarr = [[p̄[ntuple(x->Colon(),Val(N-2))...,j,i] for j in 1:size(p̄)[end-1]] for i in 1:size(p̄)[end]]
     (EnsembleSolution(arrarr, 0.0, true),nothing,nothing)
   end
+  function EnsembleSolution_adjoint(p̄::AbstractArray{<:AbstractArray,1})where {T}
+    (EnsembleSolution(p̄, 0.0, true),nothing,nothing)
+  end
   function EnsembleSolution_adjoint(p̄::EnsembleSolution)
     (p̄,nothing,nothing)
   end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -67,6 +67,9 @@ function solve(prob::DEProblem,args...;sensealg=nothing,
                u0 = nothing, p = nothing, kwargs...)
   u0 = u0 !== nothing ? u0 : prob.u0
   p  = p  !== nothing ? p  : prob.p
+  if sensealg === nothing && hasproperty(prob,:kwargs) && haskey(prob.kwargs,:sensealg)
+    sensealg = prob.kwargs[:sensealg]
+  end
   solve_up(prob,sensealg,u0,p,args...;kwargs...)
 end
 

--- a/test/downstream/ensemble_ad.jl
+++ b/test/downstream/ensemble_ad.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, Zygote, Test
+using OrdinaryDiffEq, ForwardDiff, Zygote, Test
 using DiffEqSensitivity
 using Random
 
@@ -41,3 +41,46 @@ test_loss(p,prob_ode)
 	test_loss(p,prob_ode)
 end
 @test gs[1] isa Vector
+
+
+### https://github.com/SciML/DiffEqFlux.jl/issues/595
+
+function fiip(du,u,p,t)
+  du[1] = dx = p[1]*u[1] - p[2]*u[1]*u[2]
+  du[2] = dy = -p[3]*u[2] + p[4]*u[1]*u[2]
+end
+
+p = [1.5,1.0,3.0,1.0]; u0 = [1.0;1.0]
+prob = ODEProblem(fiip,u0,(0.0,10.0),p)
+sol = solve(prob,Tsit5())
+
+function sum_of_solution(x)
+    _prob = remake(prob,u0=x[1:2],p=x[3:end])
+    sum(solve(_prob,Tsit5(),saveat=0.1))
+end
+Zygote.gradient(sum_of_solution,[u0;p])
+
+# Testing ensemble problem. Works with ForwardDiff. Does not work with Zygote.
+N = 3
+eu0 = rand(N,2)
+ep = rand(N,4)
+
+ensemble_prob = EnsembleProblem(prob, prob_func=(prob, i, repeat)->remake(prob, u0=eu0[i,:], p=ep[i,:],saveat=0.1))
+esol = solve(ensemble_prob, Tsit5(), trajectories=N)
+
+cache = Ref{Any}()
+
+function sum_of_e_solution(p)
+    ensemble_prob = EnsembleProblem(prob, prob_func=(prob, i, repeat)->remake(prob, u0=eu0[i,:],p=p[i,:],saveat=0.1))
+    sol = solve(ensemble_prob,Tsit5(),EnsembleSerial(),trajectories=N,abstol=1e-12,reltol=1e-12)
+    z = Array(sol[1])
+    cache[] = sol[1].t
+    sum(z) # just test for the first solutions, gradients should be zero for others
+end
+
+sum_of_e_solution(ep)
+
+x = ForwardDiff.gradient(sum_of_e_solution, ep)
+y = Zygote.gradient(sum_of_e_solution, ep)[1] # Zygote second to test cache of forward pass
+@test x ≈ y
+@test cache[] == 0:0.1:10.0 # test prob.kwargs is forwarded


### PR DESCRIPTION
This is the correct way to fix https://github.com/SciML/DiffEqFlux.jl/issues/595, though it will need a followup in DiffEqSensitivity since there was some hardcoded forwarding of specific arguments in there before. Now, none of the concrete_solve dispatches need to handle any of the cases, which will make it much more sane and ensure that the adjoint forward pass always matches the regular forward pass.