### PR TITLE
Type stable NamedTuple creation

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -16,7 +16,7 @@ function init_call(_prob,args...;merge_callbacks = true,kwargs...)
     if merge_callbacks && haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
       kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
       values(kwargs)), (:callback,))}(values(kwargs))
-      callbacks = NamedTuple{(:callback,)}( [DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback )] )
+      callbacks = NamedTuple{(:callback,)}( (DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback ),) )
       kwargs = merge(kwargs_temp, callbacks)
     end
     kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
@@ -335,7 +335,7 @@ function _solve_adjoint(prob,sensealg,u0,p,args...;merge_callbacks = true, kwarg
     if merge_callbacks && haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
       kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
       values(kwargs)), (:callback,))}(values(kwargs))
-      callbacks = NamedTuple{(:callback,)}( [DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback )] )
+      callbacks = NamedTuple{(:callback,)}( (DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback ),) )
       kwargs = merge(kwargs_temp, callbacks)
     end
     kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
@@ -366,7 +366,7 @@ function _solve_forward(prob,sensealg,u0,p,args...;merge_callbacks = true, kwarg
     if merge_callbacks && haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
       kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
       values(kwargs)), (:callback,))}(values(kwargs))
-      callbacks = NamedTuple{(:callback,)}( [DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback )] )
+      callbacks = NamedTuple{(:callback,)}( (DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback ),) )
       kwargs = merge(kwargs_temp, callbacks)
     end
     kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -49,7 +49,7 @@ function solve_call(_prob,args...;merge_callbacks = true, kwargs...)
     if merge_callbacks && haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
       kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
       values(kwargs)), (:callback,))}(values(kwargs))
-      callbacks = NamedTuple{(:callback,)}( [DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback )] )
+      callbacks = NamedTuple{(:callback,)}( (DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback ),) )
       kwargs = merge(kwargs_temp, callbacks)
     end
     kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)


### PR DESCRIPTION
Current version allocates memory by creating a vector instead of a tuple so that the subsequent named tuple can be type unstable. I switched to creating a tuple, instead.