### PR TITLE
Avoid RecursiveFactorization except on simple number types

### DIFF
--- a/src/linear_nonlinear.jl
+++ b/src/linear_nonlinear.jl
@@ -101,7 +101,7 @@ function (p::DefaultLinSolve)(x,A::Union{AbstractMatrix,AbstractDiffEqOperator},
         p.openblas = isopenblas()
       end
 
-      if ArrayInterface.can_setindex(x) && (size(A,1) <= 100 || (p.openblas && size(A,1) <= 500))
+      if eltype(A) <: Union{Float32,Float64,ComplexF32,ComplexF64} && ArrayInterface.can_setindex(x) && (size(A,1) <= 100 || (p.openblas && size(A,1) <= 500))
         p.A = RecursiveFactorization.lu!(A)
       else
         p.A = lu!(A)


### PR DESCRIPTION
```julia
using OrdinaryDiffEq, SnoopCompile, ForwardDiff

lorenz = (du,u,p,t) -> begin
        du[1] = 10.0(u[2]-u[1])
        du[2] = u[1]*(28.0-u[3]) - u[2]
        du[3] = u[1]*u[2] - (8/3)*u[3]
end

u0 = [1.0;0.0;0.0]; tspan = (0.0,100.0);
prob = ODEProblem(lorenz,u0,tspan); alg = Rodas5();
tinf = @snoopi_deep ForwardDiff.gradient(u0 -> sum(solve(ODEProblem(lorenz,u0,tspan),alg)), u0)
```

Before:

```julia
InferenceTimingNode: 1.720146/12.692469 on Core.Compiler.Timings.ROOT() with 32 direct children
```

After:

```julia
InferenceTimingNode: 1.243689/4.828318 on Core.Compiler.Timings.ROOT() with 33 direct children
```
