### PR TITLE
Backport ChainRulesCore 1.0 support to 6.59

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.59.0"
+version = "6.59.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
 ArrayInterface = "2.6, 3.0"
-ChainRulesCore = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9"
+ChainRulesCore = "0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0"
 DataStructures = "0.18"
 DocStringExtensions = "0.8"
 FunctionWrappers = "1.0"


### PR DESCRIPTION
This PR backports support for ChainRulesCore 1.0 to DiffEqBase 6.59. The PR is made against the `6_59_backport` branch. If tests pass, this can be merged and a new release 6.59.1 can be made off of the backport branch.