### PR TITLE
add NoInit to import from SciML

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -83,7 +83,7 @@ using SciMLBase: @def, DEIntegrator, DEProblem, AbstractDiffEqOperator,
                  calculate_ensemble_errors, DEFAULT_UPDATE_FUNC, isconstant,
                  DEFAULT_REDUCTION, isautodifferentiable,
                  isadaptive, isdiscrete, has_syms, AbstractAnalyticalSolution,
-                 RECOMPILE_BY_DEFAULT
+                 RECOMPILE_BY_DEFAULT, NoInit
 
 import SciMLBase: solve, init, solve!, __init, __solve, update_coefficients!,
                   update_coefficients, isadaptive, wrapfun_oop, wrapfun_iip,


### PR DESCRIPTION
Follow up to https://github.com/SciML/SciMLBase.jl/pull/145 to import `NoInit()`. Requires a tag in SciMLBase for tests to pass to set a minimum in the project toml 