### PR TITLE
Add a common kwarg warning system

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -28,7 +28,7 @@ import ChainRulesCore
 import LabelledArrays
 import RecursiveArrayTools
 
-import ChainRulesCore: NoTangent, @ignore_derivatives
+import ChainRulesCore: NoTangent, @non_differentiable
 import ZygoteRules
 
 import DEDataArrays: DEDataArray, DEDataVector, DEDataMatrix, copy_fields!

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -28,7 +28,7 @@ import ChainRulesCore
 import LabelledArrays
 import RecursiveArrayTools
 
-import ChainRulesCore: NoTangent
+import ChainRulesCore: NoTangent, @ignore_derivatives
 import ZygoteRules
 
 import DEDataArrays: DEDataArray, DEDataVector, DEDataMatrix, copy_fields!

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -151,4 +151,6 @@ export NLNewton, NLFunctional, NLAnderson
 
 export SensitivityADPassThrough
 
+export KeywordArgError, KeywordArgWarn, KeywordArgSilent
+
 end # module

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -61,6 +61,8 @@ const allowedkeywords = (
   :seed,
   :alg_hints,
   :kwargshandle,
+  :trajectories,
+  :batch_size,
 )
 
 const KWARGWARN_MESSAGE = 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -118,7 +118,7 @@ function init_call(_prob, args...; merge_callbacks=true, kwargs...)
 end
 
 function init(prob::DEProblem, args...; kwargshandle=KeywordArgWarn, kwargs...)
-  checkkwargs(kwargshandle; kwargs...)
+  @ignore_derivatives checkkwargs(kwargshandle; kwargs...)
   if haskey(kwargs, :alg) && (isempty(args) || args[1] === nothing)
     alg = kwargs[:alg]
     _prob = get_concrete_problem(prob, isadaptive(alg); kwargs...)
@@ -159,7 +159,7 @@ function solve(prob::DEProblem, args...; sensealg=nothing,
   if sensealg === nothing && haskey(prob.kwargs, :sensealg)
     sensealg = prob.kwargs[:sensealg]
   end
-  checkkwargs(kwargshandle; kwargs...)
+  @ignore_derivatives checkkwargs(kwargshandle; kwargs...)
   solve_up(prob, sensealg, u0, p, args...; kwargs...)
 end
 
@@ -200,7 +200,7 @@ function solve(prob::AbstractJumpProblem, args...; kwargs...)
   __solve(prob, args...; kwargs...)
 end
 
-@ignore_derivatives function checkkwargs(kwargshandle; kwargs...)
+function checkkwargs(kwargshandle; kwargs...)
   if any(x -> x ∉ allowedkeywords, keys(kwargs))
     if kwargshandle == KeywordArgError
       throw(CommonKwargError(kwargs))

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -118,7 +118,7 @@ function init_call(_prob, args...; merge_callbacks=true, kwargs...)
 end
 
 function init(prob::DEProblem, args...; kwargshandle=KeywordArgWarn, kwargs...)
-  @ignore_derivatives checkkwargs(kwargshandle; kwargs...)
+  checkkwargs(kwargshandle; kwargs...)
   if haskey(kwargs, :alg) && (isempty(args) || args[1] === nothing)
     alg = kwargs[:alg]
     _prob = get_concrete_problem(prob, isadaptive(alg); kwargs...)
@@ -159,7 +159,7 @@ function solve(prob::DEProblem, args...; sensealg=nothing,
   if sensealg === nothing && haskey(prob.kwargs, :sensealg)
     sensealg = prob.kwargs[:sensealg]
   end
-  @ignore_derivatives checkkwargs(kwargshandle; kwargs...)
+  checkkwargs(kwargshandle; kwargs...)
   solve_up(prob, sensealg, u0, p, args...; kwargs...)
 end
 
@@ -211,6 +211,8 @@ function checkkwargs(kwargshandle; kwargs...)
     end
   end
 end
+
+@non_differentiable checkkwargs(kwargshandle)
 
 function get_concrete_problem(prob::AbstractJumpProblem, isadapt; kwargs...)
   prob

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -3,111 +3,210 @@ struct EvalFunc{F} <: Function
 end
 (f::EvalFunc)(args...) = f.f(args...)
 
-NO_TSPAN_PROBS = Union{AbstractLinearProblem, AbstractNonlinearProblem,
-                       AbstractQuadratureProblem,
-                       AbstractSteadyStateProblem,AbstractJumpProblem}
+NO_TSPAN_PROBS = Union{AbstractLinearProblem,AbstractNonlinearProblem,
+  AbstractQuadratureProblem,
+  AbstractSteadyStateProblem,AbstractJumpProblem}
 
 has_kwargs(_prob::DEProblem) = has_kwargs(typeof(_prob))
-Base.@pure has_kwargs(::Type{T}) where T = :kwargs ∈ fieldnames(T)
+Base.@pure has_kwargs(::Type{T}) where {T} = :kwargs ∈ fieldnames(T)
 
-function init_call(_prob,args...;merge_callbacks = true,kwargs...)
+const allowedkeywords = (
+  :dense,
+  :saveat,
+  :save_idxs,
+  :tstops,
+  :d_discontinuities,
+  :save_everystep,
+  :save_on,
+  :save_start,
+  :save_end,
+  :initialize_save,
+  :adaptive,
+  :abstol,
+  :reltol,
+  :dt,
+  :dtmax,
+  :dtmin,
+  :force_dtmin,
+  :internalnorm,
+  :controller,
+  :gamma,
+  :beta1,
+  :beta2,
+  :qmax,
+  :qmin,
+  :qsteady_min,
+  :qsteady_max,
+  :qoldinit,
+  :failfactor,
+  :calck,
+  :alias_u0,
+  :maxiters,
+  :callback,
+  :isoutofdomain,
+  :unstable_check,
+  :verbose,
+  :merge_callbacks,
+  :progress,
+  :progress_steps,
+  :progress_name,
+  :progress_message,
+  :timeseries_errors,
+  :dense_errors,
+  :calculate_errors,
+  :initializealg,
+  :alg,
+  :save_noise,
+  :delta,
+  :seed,
+  :alg_hints,
+  :kwargshandle,
+)
+
+const KWARGWARN_MESSAGE = 
+"""
+Warning: Unrecognized keyword arguments found. Future versions will error.
+The only allowed keyword arguments to `solve` are: 
+$allowedkeywords
+See https://diffeq.sciml.ai/stable/basics/common_solver_opts/ for more details.
+
+Set kwargshandle=KeywordArgError for an error message and more details.
+Set kwargshandle=KeywordArgSilent to ignore this message.
+"""
+
+const KWARGERROR_MESSAGE = 
+"""
+Error: Unrecognized keyword arguments found.
+The only allowed keyword arguments to `solve` are: 
+$allowedkeywords
+See https://diffeq.sciml.ai/stable/basics/common_solver_opts/ for more details.
+"""
+
+struct CommonKwargError <: Exception 
+  kwargs
+end
+
+function Base.showerror(io::IO, e::CommonKwargError)
+  println(io, KWARGERROR_MESSAGE)
+  notin = collect(map(x -> x ∉ allowedkeywords, keys(e.kwargs)))
+  unrecognized = collect(keys(e.kwargs))[notin]
+  print(io, "Unrecognized keyword arguments: $unrecognized")
+end
+
+@enum KeywordArgError KeywordArgWarn KeywordArgSilent
+
+function init_call(_prob, args...; merge_callbacks=true, kwargs...)
 
   if has_kwargs(_prob)
-    if merge_callbacks && haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
+    if merge_callbacks && haskey(_prob.kwargs, :callback) && haskey(kwargs, :callback)
       kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
-      values(kwargs)), (:callback,))}(values(kwargs))
-      callbacks = NamedTuple{(:callback,)}( (DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback ),) )
+          values(kwargs)), (:callback,))}(values(kwargs))
+      callbacks = NamedTuple{(:callback,)}((DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback),))
       kwargs = merge(kwargs_temp, callbacks)
     end
     kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
   end
 
-  if hasfield(typeof(_prob),:f) && hasfield(typeof(_prob.f),:f) && typeof(_prob.f.f) <: EvalFunc
-    Base.invokelatest(__init,_prob,args...; kwargs...)#::T
+  if hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) && typeof(_prob.f.f) <: EvalFunc
+    Base.invokelatest(__init, _prob, args...; kwargs...)#::T
   else
-    __init(_prob,args...;kwargs...)#::T
+    __init(_prob, args...; kwargs...)#::T
   end
 end
 
-function init(prob::DEProblem,args...;kwargs...)
-  if haskey(kwargs,:alg) && (isempty(args) || args[1] === nothing)
+function init(prob::DEProblem, args...; kwargshandle=KeywordArgWarn, kwargs...)
+  checkkwargs(kwargshandle; kwargs...)
+  if haskey(kwargs, :alg) && (isempty(args) || args[1] === nothing)
     alg = kwargs[:alg]
-    _prob = get_concrete_problem(prob,isadaptive(alg);kwargs...)
-    init_call(_prob,alg,args...;kwargs...)
+    _prob = get_concrete_problem(prob, isadaptive(alg); kwargs...)
+    init_call(_prob, alg, args...; kwargs...)
   elseif !isempty(args) && typeof(args[1]) <: DEAlgorithm
     alg = args[1]
-    _prob = get_concrete_problem(prob,isadaptive(alg);kwargs...)
-    init_call(_prob,args...;kwargs...)
+    _prob = get_concrete_problem(prob, isadaptive(alg); kwargs...)
+    init_call(_prob, args...; kwargs...)
   else
-    _prob = get_concrete_problem(prob,!(typeof(prob)<:DiscreteProblem);kwargs...)
-    init_call(_prob,args...;kwargs...)
+    _prob = get_concrete_problem(prob, !(typeof(prob) <: DiscreteProblem); kwargs...)
+    init_call(_prob, args...; kwargs...)
   end
 end
 
-function solve_call(_prob,args...;merge_callbacks = true, kwargs...)
+function solve_call(_prob, args...; merge_callbacks=true, kwargs...)
   if has_kwargs(_prob)
-    if merge_callbacks && haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
+    if merge_callbacks && haskey(_prob.kwargs, :callback) && haskey(kwargs, :callback)
       kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
-      values(kwargs)), (:callback,))}(values(kwargs))
-      callbacks = NamedTuple{(:callback,)}( (DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback ),) )
+          values(kwargs)), (:callback,))}(values(kwargs))
+      callbacks = NamedTuple{(:callback,)}((DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback),))
       kwargs = merge(kwargs_temp, callbacks)
     end
     kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
   end
 
-  if hasfield(typeof(_prob),:f) && hasfield(typeof(_prob.f),:f) && typeof(_prob.f.f) <: EvalFunc
-    Base.invokelatest(__solve,_prob,args...; kwargs...)#::T
+  if hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) && typeof(_prob.f.f) <: EvalFunc
+    Base.invokelatest(__solve, _prob, args...; kwargs...)#::T
   else
-    __solve(_prob,args...;kwargs...)#::T
+    __solve(_prob, args...; kwargs...)#::T
   end
 end
 
 # save_idxs and saveat are here due to https://github.com/FluxML/Zygote.jl/issues/664
-function solve(prob::DEProblem,args...;sensealg=nothing,
-               u0 = nothing, p = nothing, kwargs...)
+function solve(prob::DEProblem, args...; sensealg=nothing,
+  u0=nothing, p=nothing, kwargshandle=KeywordArgWarn, kwargs...)
   u0 = u0 !== nothing ? u0 : prob.u0
-  p  = p  !== nothing ? p  : prob.p
-  if sensealg === nothing && haskey(prob.kwargs,:sensealg)
+  p = p !== nothing ? p : prob.p
+  if sensealg === nothing && haskey(prob.kwargs, :sensealg)
     sensealg = prob.kwargs[:sensealg]
   end
-  solve_up(prob,sensealg,u0,p,args...;kwargs...)
+  checkkwargs(kwargshandle; kwargs...)
+  solve_up(prob, sensealg, u0, p, args...; kwargs...)
 end
 
-function solve_up(prob::DEProblem,sensealg,u0,p,args...;kwargs...)
+function solve_up(prob::DEProblem, sensealg, u0, p, args...; kwargs...)
 
-  if haskey(kwargs,:alg) && (isempty(args) || args[1] === nothing)
+  if haskey(kwargs, :alg) && (isempty(args) || args[1] === nothing)
     alg = kwargs[:alg]
-    _alg = prepare_alg(alg,u0,p,prob)
-    _prob = get_concrete_problem(prob,isadaptive(_alg);u0=u0,p=p,kwargs...)
-    solve_call(_prob,_alg,args...;kwargs...)
+    _alg = prepare_alg(alg, u0, p, prob)
+    _prob = get_concrete_problem(prob, isadaptive(_alg); u0=u0, p=p, kwargs...)
+    solve_call(_prob, _alg, args...; kwargs...)
   elseif !isempty(args) && typeof(args[1]) <: DEAlgorithm
     alg = args[1]
-    _alg = prepare_alg(alg,u0,p,prob)
-    _prob = get_concrete_problem(prob,isadaptive(_alg);u0=u0,p=p,kwargs...)
-    solve_call(_prob,_alg,Base.tail(args)...;kwargs...)
+    _alg = prepare_alg(alg, u0, p, prob)
+    _prob = get_concrete_problem(prob, isadaptive(_alg); u0=u0, p=p, kwargs...)
+    solve_call(_prob, _alg, Base.tail(args)...; kwargs...)
   elseif isempty(args) # Default algorithm handling
-    _prob = get_concrete_problem(prob,!(typeof(prob)<:DiscreteProblem);u0=u0,p=p,kwargs...)
-    solve_call(_prob,args...;kwargs...)
+    _prob = get_concrete_problem(prob, !(typeof(prob) <: DiscreteProblem); u0=u0, p=p, kwargs...)
+    solve_call(_prob, args...; kwargs...)
   else
-    _prob = get_concrete_problem(prob,!(typeof(prob)<:DiscreteProblem);u0=u0,p=p,kwargs...)
-    solve_call(_prob,args...;kwargs...)
+    _prob = get_concrete_problem(prob, !(typeof(prob) <: DiscreteProblem); u0=u0, p=p, kwargs...)
+    solve_call(_prob, args...; kwargs...)
   end
 end
 
-function solve(prob::EnsembleProblem,args...;kwargs...)
-  if isempty(args) || length(args) == 1 && typeof(args[1])<:EnsembleAlgorithm
-    __solve(prob,nothing,args...;kwargs...)
+function solve(prob::EnsembleProblem, args...; kwargs...)
+  if isempty(args) || length(args) == 1 && typeof(args[1]) <: EnsembleAlgorithm
+    __solve(prob, nothing, args...; kwargs...)
   else
-    __solve(prob,args...;kwargs...)
+    __solve(prob, args...; kwargs...)
   end
 end
 
-function solve(prob::AbstractNoiseProblem,args...; kwargs...)
-  __solve(prob,args...;kwargs...)
+function solve(prob::AbstractNoiseProblem, args...; kwargs...)
+  __solve(prob, args...; kwargs...)
 end
 
-function solve(prob::AbstractJumpProblem,args...; kwargs...)
-  __solve(prob,args...;kwargs...)
+function solve(prob::AbstractJumpProblem, args...; kwargs...)
+  __solve(prob, args...; kwargs...)
+end
+
+function checkkwargs(kwargshandle; kwargs...)
+  if any(x -> x ∉ allowedkeywords, keys(kwargs))
+    if kwargshandle == KeywordArgError
+      throw(CommonKwargError(kwargs))
+    elseif kwargshandle == KeywordArgWarn
+      @warn KWARGWARN_MESSAGE
+    else
+      @assert kwargshandle == KeywordArgSilent
+    end
+  end
 end
 
 function get_concrete_problem(prob::AbstractJumpProblem, isadapt; kwargs...)
@@ -117,27 +216,27 @@ end
 function get_concrete_problem(prob::SteadyStateProblem, isadapt; kwargs...)
   u0 = get_concrete_u0(prob, isadapt, Inf, kwargs)
   u0 = promote_u0(u0, prob.p, nothing)
-  remake(prob; u0 = u0)
+  remake(prob; u0=u0)
 end
 
 function get_concrete_problem(prob::NonlinearProblem, isadapt; kwargs...)
   u0 = get_concrete_u0(prob, isadapt, nothing, kwargs)
   u0 = promote_u0(u0, prob.p, nothing)
-  remake(prob; u0 = u0)
+  remake(prob; u0=u0)
 end
 
 function get_concrete_problem(prob::AbstractEnsembleProblem, isadapt; kwargs...)
   prob
 end
 
-function solve(prob::PDEProblem,alg::DiffEqBase.DEAlgorithm,args...;
-                                          kwargs...)
-    solve(prob.prob,alg,args...;kwargs...)
+function solve(prob::PDEProblem, alg::DiffEqBase.DEAlgorithm, args...;
+  kwargs...)
+  solve(prob.prob, alg, args...; kwargs...)
 end
 
-function init(prob::PDEProblem,alg::DiffEqBase.DEAlgorithm,args...;
-                                          kwargs...)
-    init(prob.prob,alg,args...;kwargs...)
+function init(prob::PDEProblem, alg::DiffEqBase.DEAlgorithm, args...;
+  kwargs...)
+  init(prob.prob, alg, args...; kwargs...)
 end
 
 function get_concrete_problem(prob, isadapt; kwargs...)
@@ -148,11 +247,11 @@ function get_concrete_problem(prob, isadapt; kwargs...)
   f_promote = promote_f(prob.f, u0_promote)
   tspan_promote = promote_tspan(u0_promote, p, tspan, prob, kwargs)
   if isconcreteu0(prob, tspan[1], kwargs) && typeof(u0_promote) === typeof(prob.u0) &&
-                  prob.tspan == tspan && typeof(prob.tspan) === typeof(tspan_promote) &&
-                  p === prob.p && f_promote === prob.f
+     prob.tspan == tspan && typeof(prob.tspan) === typeof(tspan_promote) &&
+     p === prob.p && f_promote === prob.f
     return prob
   else
-    return remake(prob; f = f_promote, u0 = u0_promote, p=p, tspan = tspan_promote)
+    return remake(prob; f=f_promote, u0=u0_promote, p=p, tspan=tspan_promote)
   end
 end
 
@@ -170,11 +269,11 @@ function get_concrete_problem(prob::DAEProblem, isadapt; kwargs...)
   tspan_promote = promote_tspan(u0_promote, p, tspan, prob, kwargs)
   if isconcreteu0(prob, tspan[1], kwargs) && typeof(u0_promote) === typeof(prob.u0) &&
      isconcretedu0(prob, tspan[1], kwargs) && typeof(du0_promote) === typeof(prob.du0) &&
-                  prob.tspan == tspan && typeof(prob.tspan) === typeof(tspan_promote) &&
-                  p === prob.p && f_promote === prob.f
+     prob.tspan == tspan && typeof(prob.tspan) === typeof(tspan_promote) &&
+     p === prob.p && f_promote === prob.f
     return prob
   else
-    return remake(prob; f = f_promote, du0 = du0_promote, u0 = u0_promote, p=p, tspan = tspan_promote)
+    return remake(prob; f=f_promote, du0=du0_promote, u0=u0_promote, p=p, tspan=tspan_promote)
   end
 end
 
@@ -192,26 +291,26 @@ function get_concrete_problem(prob::DDEProblem, isadapt; kwargs...)
   u0 = promote_u0(u0, p, tspan[1])
   tspan = promote_tspan(u0, p, tspan, prob, kwargs)
 
-  remake(prob; u0 = u0, tspan = tspan, p=p, constant_lags = constant_lags)
+  remake(prob; u0=u0, tspan=tspan, p=p, constant_lags=constant_lags)
 end
 
-function promote_f(f::F,u0) where F
-    # Ensure our jacobian will be of the same type as u0
-    uElType = u0 === nothing ? Float64 : eltype(u0)
-    if isdefined(f, :jac_prototype) && f.jac_prototype isa AbstractArray
-        f = @set f.jac_prototype = similar(f.jac_prototype, uElType)
-    end
-    return f
+function promote_f(f::F, u0) where {F}
+  # Ensure our jacobian will be of the same type as u0
+  uElType = u0 === nothing ? Float64 : eltype(u0)
+  if isdefined(f, :jac_prototype) && f.jac_prototype isa AbstractArray
+    f = @set f.jac_prototype = similar(f.jac_prototype, uElType)
+  end
+  return f
 end
 
-promote_f(f::SplitFunction,u0) = typeof(f.cache) === typeof(u0) && isinplace(f) ? f : remake(f,cache=zero(u0))
-prepare_alg(alg,u0,p,f) = alg
+promote_f(f::SplitFunction, u0) = typeof(f.cache) === typeof(u0) && isinplace(f) ? f : remake(f, cache=zero(u0))
+prepare_alg(alg, u0, p, f) = alg
 
 function get_concrete_tspan(prob, isadapt, kwargs, p)
   if prob.tspan isa Function
     tspan = prob.tspan(p)
   elseif haskey(kwargs, :tspan)
-      tspan = kwargs[:tspan]
+    tspan = kwargs[:tspan]
   elseif prob.tspan === (nothing, nothing)
     error("No tspan is set in the problem or chosen in the init/solve call")
   else
@@ -234,7 +333,7 @@ end
 function get_concrete_u0(prob, isadapt, t0, kwargs)
   if eval_u0(prob.u0)
     u0 = prob.u0(prob.p, t0)
-  elseif haskey(kwargs,:u0)
+  elseif haskey(kwargs, :u0)
     u0 = kwargs[:u0]
   else
     u0 = prob.u0
@@ -248,7 +347,7 @@ end
 function get_concrete_du0(prob, isadapt, t0, kwargs)
   if eval_u0(prob.du0)
     du0 = prob.du0(prob.p, t0)
-  elseif haskey(kwargs,:du0)
+  elseif haskey(kwargs, :du0)
     du0 = kwargs[:du0]
   else
     du0 = prob.du0
@@ -260,7 +359,7 @@ function get_concrete_du0(prob, isadapt, t0, kwargs)
 end
 
 function get_concrete_p(prob, kwargs)
-  if haskey(kwargs,:p)
+  if haskey(kwargs, :p)
     p = kwargs[:p]
   else
     p = prob.p
@@ -274,7 +373,7 @@ isdistribution(_u0::Distributions.Sampleable) = true
 eval_u0(u0::Function) = true
 eval_u0(u0) = false
 
-function __solve(prob::DEProblem,args...;default_set=false,second_time=false,kwargs...)
+function __solve(prob::DEProblem, args...; default_set=false, second_time=false, kwargs...)
   if second_time
     error("""
       Default algorithm choices require DifferentialEquations.jl.
@@ -288,7 +387,7 @@ function __solve(prob::DEProblem,args...;default_set=false,second_time=false,kwa
   elseif length(args) > 0 && !(typeof(args[1]) <: Union{Nothing,DEAlgorithm})
     error("Inappropiate solve command. The arguments do not make sense. Likely, you gave an algorithm which does not actually exist (or does not `<:DiffEqBase.DEAlgorithm`)")
   else
-    __solve(prob::DEProblem,nothing,args...;default_set=false,second_time=true,kwargs...)
+    __solve(prob::DEProblem, nothing, args...; default_set=false, second_time=true, kwargs...)
   end
 end
 
@@ -296,93 +395,93 @@ end
 
 struct SensitivityADPassThrough <: SciMLBase.DEAlgorithm end
 
-function ChainRulesCore.frule(::typeof(solve_up),prob,
-                              sensealg::Union{Nothing,AbstractSensitivityAlgorithm},
-                              u0,p,args...;
-                              kwargs...)
-  _solve_forward(prob,sensealg,u0,p,args...;kwargs...)
+function ChainRulesCore.frule(::typeof(solve_up), prob,
+  sensealg::Union{Nothing,AbstractSensitivityAlgorithm},
+  u0, p, args...;
+  kwargs...)
+  _solve_forward(prob, sensealg, u0, p, args...; kwargs...)
 end
 
-function ChainRulesCore.rrule(::typeof(solve_up),prob::SciMLBase.DEProblem,
-                              sensealg::Union{Nothing,AbstractSensitivityAlgorithm},
-                              u0,p,args...;
-                              kwargs...)
-  _solve_adjoint(prob,sensealg,u0,p,args...;kwargs...)
+function ChainRulesCore.rrule(::typeof(solve_up), prob::SciMLBase.DEProblem,
+  sensealg::Union{Nothing,AbstractSensitivityAlgorithm},
+  u0, p, args...;
+  kwargs...)
+  _solve_adjoint(prob, sensealg, u0, p, args...; kwargs...)
 end
 
 ###
 ### Legacy Dispatches to be Non-Breaking
 ###
 
-@deprecate concrete_solve(prob::SciMLBase.DEProblem,alg::Union{SciMLBase.DEAlgorithm,Nothing},
-                        u0=prob.u0,p=prob.p,args...;kwargs...) solve(prob,alg,args...;u0=u0,p=p,kwargs...)
+@deprecate concrete_solve(prob::SciMLBase.DEProblem, alg::Union{SciMLBase.DEAlgorithm,Nothing},
+  u0=prob.u0, p=prob.p, args...; kwargs...) solve(prob, alg, args...; u0=u0, p=p, kwargs...)
 
-function _solve_adjoint(prob,sensealg,u0,p,args...;merge_callbacks = true, kwargs...)
+function _solve_adjoint(prob, sensealg, u0, p, args...; merge_callbacks=true, kwargs...)
 
-  _prob = if haskey(kwargs,:alg) && (isempty(args) || args[1] === nothing)
+  _prob = if haskey(kwargs, :alg) && (isempty(args) || args[1] === nothing)
     alg = kwargs[:alg]
-    get_concrete_problem(prob,isadaptive(alg);u0=u0,p=p,kwargs...)
+    get_concrete_problem(prob, isadaptive(alg); u0=u0, p=p, kwargs...)
   elseif !isempty(args) && typeof(args[1]) <: DEAlgorithm
     alg = args[1]
-    get_concrete_problem(prob,isadaptive(alg);u0=u0,p=p,kwargs...)
+    get_concrete_problem(prob, isadaptive(alg); u0=u0, p=p, kwargs...)
   elseif isempty(args) # Default algorithm handling
-    get_concrete_problem(prob,!(typeof(prob)<:DiscreteProblem);u0=u0,p=p,kwargs...)
+    get_concrete_problem(prob, !(typeof(prob) <: DiscreteProblem); u0=u0, p=p, kwargs...)
   else
-    get_concrete_problem(prob,!(typeof(prob)<:DiscreteProblem);u0=u0,p=p,kwargs...)
+    get_concrete_problem(prob, !(typeof(prob) <: DiscreteProblem); u0=u0, p=p, kwargs...)
   end
 
   if has_kwargs(_prob)
-    if merge_callbacks && haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
+    if merge_callbacks && haskey(_prob.kwargs, :callback) && haskey(kwargs, :callback)
       kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
-      values(kwargs)), (:callback,))}(values(kwargs))
-      callbacks = NamedTuple{(:callback,)}( (DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback ),) )
+          values(kwargs)), (:callback,))}(values(kwargs))
+      callbacks = NamedTuple{(:callback,)}((DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback),))
       kwargs = merge(kwargs_temp, callbacks)
     end
     kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
   end
 
   if isempty(args)
-    _concrete_solve_adjoint(_prob,nothing,sensealg,u0,p;kwargs...)
+    _concrete_solve_adjoint(_prob, nothing, sensealg, u0, p; kwargs...)
   else
-    _concrete_solve_adjoint(_prob,args[1],sensealg,u0,p,Base.tail(args)...;kwargs...)
+    _concrete_solve_adjoint(_prob, args[1], sensealg, u0, p, Base.tail(args)...; kwargs...)
   end
 end
 
-function _solve_forward(prob,sensealg,u0,p,args...;merge_callbacks = true, kwargs...)
+function _solve_forward(prob, sensealg, u0, p, args...; merge_callbacks=true, kwargs...)
 
-  _prob = if haskey(kwargs,:alg) && (isempty(args) || args[1] === nothing)
+  _prob = if haskey(kwargs, :alg) && (isempty(args) || args[1] === nothing)
     alg = kwargs[:alg]
-    get_concrete_problem(prob,isadaptive(alg);u0=u0,p=p,kwargs...)
+    get_concrete_problem(prob, isadaptive(alg); u0=u0, p=p, kwargs...)
   elseif !isempty(args) && typeof(args[1]) <: DEAlgorithm
     alg = args[1]
-    get_concrete_problem(prob,isadaptive(alg);u0=u0,p=p,kwargs...)
+    get_concrete_problem(prob, isadaptive(alg); u0=u0, p=p, kwargs...)
   elseif isempty(args) # Default algorithm handling
-    get_concrete_problem(prob,!(typeof(prob)<:DiscreteProblem);u0=u0,p=p,kwargs...)
+    get_concrete_problem(prob, !(typeof(prob) <: DiscreteProblem); u0=u0, p=p, kwargs...)
   else
-    get_concrete_problem(prob,!(typeof(prob)<:DiscreteProblem);u0=u0,p=p,kwargs...)
+    get_concrete_problem(prob, !(typeof(prob) <: DiscreteProblem); u0=u0, p=p, kwargs...)
   end
 
   if has_kwargs(_prob)
-    if merge_callbacks && haskey(_prob.kwargs,:callback) && haskey(kwargs, :callback)
+    if merge_callbacks && haskey(_prob.kwargs, :callback) && haskey(kwargs, :callback)
       kwargs_temp = NamedTuple{Base.diff_names(Base._nt_names(
-      values(kwargs)), (:callback,))}(values(kwargs))
-      callbacks = NamedTuple{(:callback,)}( (DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback ),) )
+          values(kwargs)), (:callback,))}(values(kwargs))
+      callbacks = NamedTuple{(:callback,)}((DiffEqBase.CallbackSet(_prob.kwargs[:callback], values(kwargs).callback),))
       kwargs = merge(kwargs_temp, callbacks)
     end
     kwargs = isempty(_prob.kwargs) ? kwargs : merge(values(_prob.kwargs), kwargs)
   end
 
   if isempty(args)
-    _concrete_solve_forward(prob,nothing,sensealg,u0,p;kwargs...)
+    _concrete_solve_forward(prob, nothing, sensealg, u0, p; kwargs...)
   else
-    _concrete_solve_forward(prob,args[1],sensealg,u0,p,Base.tail(args)...;kwargs...)
+    _concrete_solve_forward(prob, args[1], sensealg, u0, p, Base.tail(args)...; kwargs...)
   end
 end
 
-function _concrete_solve_adjoint(args...;kwargs...)
+function _concrete_solve_adjoint(args...; kwargs...)
   error("No adjoint rules exist. Check that you added `using DiffEqSensitivity`")
 end
 
-function _concrete_solve_forward(args...;kwargs...)
+function _concrete_solve_forward(args...; kwargs...)
   error("No sensitivity rules exist. Check that you added `using DiffEqSensitivity`")
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -63,6 +63,7 @@ const allowedkeywords = (
   :kwargshandle,
   :trajectories,
   :batch_size,
+  :sensealg,
 )
 
 const KWARGWARN_MESSAGE = 
@@ -199,7 +200,7 @@ function solve(prob::AbstractJumpProblem, args...; kwargs...)
   __solve(prob, args...; kwargs...)
 end
 
-function checkkwargs(kwargshandle; kwargs...)
+@ignore_derivatives function checkkwargs(kwargshandle; kwargs...)
   if any(x -> x ∉ allowedkeywords, keys(kwargs))
     if kwargshandle == KeywordArgError
       throw(CommonKwargError(kwargs))

--- a/test/downstream/ensemble.jl
+++ b/test/downstream/ensemble.jl
@@ -16,9 +16,6 @@ sim = solve(prob2,SRIW1(),dt=1//2^(3),trajectories=10)
 @test sim[1,2] isa Matrix
 @test sim[1,2,1] isa Float64
 
-# Test Deprecations
-@test_logs (:warn, "num_monte has been replaced by trajectories") (:warn, "parallel_type has been deprecated. Please refer to the docs for the new dispatch-based system.") solve(prob2,SRIW1(),dt=1//2^(3),num_monte=10,parallel_type=:threads)
-
 sim = solve(prob2,SRIW1(),EnsembleThreads(),dt=1//2^(3),trajectories=10)
 err_sim = DiffEqBase.calculate_ensemble_errors(sim;weak_dense_errors=true)
 @test length(sim) == 10

--- a/test/downstream/kwarg_warn.jl
+++ b/test/downstream/kwarg_warn.jl
@@ -1,0 +1,13 @@
+using OrdinaryDiffEq, Test
+function lorenz(du, u, p, t)
+    du[1] = 10.0(u[2] - u[1])
+    du[2] = u[1] * (28.0 - u[3]) - u[2]
+    du[3] = u[1] * u[2] - (8 / 3) * u[3]
+end
+u0 = [1.0; 0.0; 0.0]
+tspan = (0.0, 100.0)
+prob = ODEProblem(lorenz, u0, tspan)
+@test_nowarn sol = solve(prob, Tsit5(), reltol=1e-6)
+sol = solve(prob, Tsit5(), rel_tol=1e-6)
+@test_logs (:warn, DiffEqBase.KWARGWARN_MESSAGE) sol = solve(prob, Tsit5(), rel_tol=1e-6)
+@test_throws DiffEqBase.CommonKwargError sol = solve(prob, Tsit5(), rel_tol=1e-6, kwargshandle=DiffEqBase.KeywordArgError)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,6 +39,7 @@ end
 
 if !is_APPVEYOR && GROUP == "Downstream"
     activate_downstream_env()
+    @test @safetestset "Kwarg Warnings" begin include("downstream/kwarg_warn.jl") end
     @time @safetestset "Unitful" begin include("downstream/unitful.jl") end
     @time @safetestset "Null Parameters" begin include("downstream/null_params_test.jl") end
     @time @safetestset "Ensemble Simulations" begin include("downstream/ensemble.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,7 +39,7 @@ end
 
 if !is_APPVEYOR && GROUP == "Downstream"
     activate_downstream_env()
-    @test @safetestset "Kwarg Warnings" begin include("downstream/kwarg_warn.jl") end
+    @time @safetestset "Kwarg Warnings" begin include("downstream/kwarg_warn.jl") end
     @time @safetestset "Unitful" begin include("downstream/unitful.jl") end
     @time @safetestset "Null Parameters" begin include("downstream/null_params_test.jl") end
     @time @safetestset "Ensemble Simulations" begin include("downstream/ensemble.jl") end


### PR DESCRIPTION
This has been a long time coming. The DiffEq, and more generally, SciML interfaces have a set of common keyword arguments, but it's been fairly difficult to truly enforce. The main reason is because the keyword arguments are `kwargs...` splatted down to the solvers, and then it's the solver's job to handle it. However, with so many different problem types and everything, there has been a changing list of keyword arguments over time, and some solvers re-splat the keyword arguments because of how many different kwargs they can end up getting if, for example, one wasn't using controls for parameter estimation or something.

In pre-1.0 Julia, there wasn't a good fix for downstream users as if you would error on some keyword arguments, they would have to sanitize their list before dropping to solve, but that would make downstream `simulate` functions much harder to write since half of their list would be checking for DiffEq common arguments (a list that the library authors probably only know of a subset). However, this was solved in v1.0 with NamedTuples, i.e. libraries could allow a keyword argument and let users pass `diffeq_arguments = (reltol=1e-8,abstol=1e-6)` and then do `solve(prob,alg;diffeq_arguments)`. That would then pre-sanitize. So libraries have evolved but... DiffEq had kept back for compatibility.

This introduces a system for checking keyword arguments but for the first year we should keep it conservative. I know there are some common errors out there that have arisen from this, such as `solver`, `rel_tol`, `save_at`, etc. that have mostly been swept under the rug. This will now expose them, but to keep backwards compatbility it will default to throwing an error. A new keyword argument `kwargshandle` was added to allow for silencing the warning (i.e. the old behavior), or to change it to error. The goal is to throw enough errors at everyone that it will be deprecated and be a true error in about a year's time.

That would also give us enough time to improve the documentation. Right now this lives here in https://diffeq.sciml.ai/stable/basics/common_solver_opts/, but we need to finish unifying the documentation and then have a true global set of common keyword arguments that all of the interfaces agree on which are specified at https://scimlbase.sciml.ai/dev/.