### PR TITLE
Check and throw on incompatible initial conditions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.83.2"
+version = "6.83.3"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -158,7 +158,7 @@ const NON_SOLVER_MESSAGE =
 """
 Error: The arguments to solve are incorrect.
 The second argument must be a solver choice, `solve(prob,alg)`
-where `alg` is is a `<: DEAlgorithm`, i.e. `Tsti5()`.
+where `alg` is a `<: DEAlgorithm`, i.e. `Tsti5()`.
 
 Please double check the arguments being sent to the solver.
 """

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -101,6 +101,8 @@ function Base.showerror(io::IO, e::CommonKwargError)
   print(io, "Unrecognized keyword arguments: $unrecognized")
 end
 
+@enum KeywordArgError KeywordArgWarn KeywordArgSilent
+
 const INCOMPATIBLE_U0_MESSAGE = 
 """
 Error: Initial condition incompatible with functional form.
@@ -125,7 +127,47 @@ function Base.showerror(io::IO, e::IncompatibleInitialConditionError)
   print(io, INCOMPATIBLE_U0_MESSAGE)
 end
 
-@enum KeywordArgError KeywordArgWarn KeywordArgSilent
+const NO_DEFAULT_ALGORITHM_MESSAGE = 
+"""
+Default algorithm choices require DifferentialEquations.jl.
+Please specify an algorithm (e.g., `solve(prob, Tsit5())` for an ODE)
+or import DifferentialEquations directly.
+
+You can find the list of available solvers at https://diffeq.sciml.ai/stable/solvers/ode_solve/
+and its associated pages.
+"""
+
+struct NoDefaultAlgorithmError <: Exception end
+
+function Base.showerror(io::IO, e::NoDefaultAlgorithmError)
+  print(io, NO_DEFAULT_ALGORITHM_MESSAGE)
+end
+
+const NO_TSPAN_MESSAGE = 
+"""
+No tspan is set in the problem or chosen in the init/solve call
+"""
+
+struct NoTspanError <: Exception end
+
+function Base.showerror(io::IO, e::NoTspanError)
+  print(io, NO_TSPAN_MESSAGE)
+end
+
+const NON_SOLVER_MESSAGE = 
+"""
+Error: The arguments to solve are incorrect.
+The second argument must be a solver choice, `solve(prob,alg)`
+where `alg` is is a `<: DEAlgorithm`, i.e. `Tsti5()`.
+
+Please double check the arguments being sent to the solver.
+"""
+
+struct NonSolverError <: Exception end
+
+function Base.showerror(io::IO, e::NonSolverError)
+  print(io, NON_SOLVER_MESSAGE)
+end
 
 function init_call(_prob, args...; merge_callbacks=true, kwargs...)
 
@@ -346,7 +388,7 @@ function get_concrete_tspan(prob, isadapt, kwargs, p)
   elseif haskey(kwargs, :tspan)
     tspan = kwargs[:tspan]
   elseif prob.tspan === (nothing, nothing)
-    error("No tspan is set in the problem or chosen in the init/solve call")
+    throw(NoTspanError())
   else
     tspan = prob.tspan
   end
@@ -377,7 +419,7 @@ function get_concrete_u0(prob, isadapt, t0, kwargs)
 
   _u0 = handle_distribution_u0(u0)
 
-  if isinplace(prob) && _u0 isa Number
+  if isinplace(prob) && (_u0 isa Number || _u0 isa SArray)
     throw(IncompatibleInitialConditionError())
   end
 
@@ -397,7 +439,7 @@ function get_concrete_du0(prob, isadapt, t0, kwargs)
 
   _du0 = handle_distribution_u0(du0)
 
-  if isinplace(prob) && _du0 isa Number
+  if isinplace(prob) && (_du0 isa Number || _du0 isa SArray)
     throw(IncompatibleInitialConditionError())
   end
 
@@ -421,17 +463,9 @@ eval_u0(u0) = false
 
 function __solve(prob::DEProblem, args...; default_set=false, second_time=false, kwargs...)
   if second_time
-    error("""
-      Default algorithm choices require DifferentialEquations.jl.
-      Please specify an algorithm (e.g., `solve(prob, Tsit5())` for an ODE)
-      or import DifferentialEquations directly.
-
-      You can find the list of available solvers at https://diffeq.sciml.ai/stable/solvers/ode_solve/
-      and its associated pages.
-      """
-    )
+    throw(NoDefaultAlgorithmError())
   elseif length(args) > 0 && !(typeof(args[1]) <: Union{Nothing,DEAlgorithm})
-    error("Inappropiate solve command. The arguments do not make sense. Likely, you gave an algorithm which does not actually exist (or does not `<:DiffEqBase.DEAlgorithm`)")
+    throw(NonSolverError())
   else
     __solve(prob::DEProblem, nothing, args...; default_set=false, second_time=true, kwargs...)
   end

--- a/test/downstream/solve_error_handling.jl
+++ b/test/downstream/solve_error_handling.jl
@@ -3,10 +3,20 @@ using OrdinaryDiffEq, Test
 f(u,p,t) = 2u
 u0 = 0.5
 tspan = (0.0,1.0)
-prob = ODEProblem(f,g,u0,tspan)
+prob = ODEProblem(f,u0,tspan)
 sol = solve(prob,Tsit5())
 
 function f(du, u, p, t)
     du .= 2.0 * u
 end
+prob = ODEProblem(f,u0,tspan)
+@test_throws DiffEqBase.IncompatibleInitialConditionError sol = solve(prob,Tsit5())
+
+prob = ODEProblem{false}(f,u0,tspan)
 sol = solve(prob,Tsit5())
+
+@test_throws DiffEqBase.NoDefaultAlgorithmError solve(prob,nothing)
+@test_throws DiffEqBase.NonSolverError solve(prob,5.0)
+
+prob = ODEProblem{false}(f,u0,(nothing,nothing))
+@test_throws DiffEqBase.NoTspanError solve(prob,Tsit5())

--- a/test/downstream/solve_error_handling.jl
+++ b/test/downstream/solve_error_handling.jl
@@ -1,0 +1,12 @@
+using OrdinaryDiffEq, Test
+
+f(u,p,t) = 2u
+u0 = 0.5
+tspan = (0.0,1.0)
+prob = ODEProblem(f,g,u0,tspan)
+sol = solve(prob,Tsit5())
+
+function f(du, u, p, t)
+    du .= 2.0 * u
+end
+sol = solve(prob,Tsit5())

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -40,6 +40,7 @@ end
 if !is_APPVEYOR && GROUP == "Downstream"
     activate_downstream_env()
     @time @safetestset "Kwarg Warnings" begin include("downstream/kwarg_warn.jl") end
+    @time @safetestset "Solve Error Handling" begin include("downstream/solve_error_handling.jl") end
     @time @safetestset "Unitful" begin include("downstream/unitful.jl") end
     @time @safetestset "Null Parameters" begin include("downstream/null_params_test.jl") end
     @time @safetestset "Ensemble Simulations" begin include("downstream/ensemble.jl") end


### PR DESCRIPTION
Fixes the issue discussed in https://discourse.julialang.org/t/blog-post-about-my-experiences-with-julia/79976/84. A better fix is for this to be addressed at the Julia level, i.e. https://github.com/JuliaLang/julia/issues/45086, though we might as well catch and throw before the solve to keep the stacktrace small.