### PR TITLE
Better error message for incompatible solver + problem pairings

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -227,11 +227,15 @@ end
 function init(prob::DEProblem, args...; kwargs...)
   if haskey(kwargs, :alg) && (isempty(args) || args[1] === nothing)
     alg = kwargs[:alg]
+    _alg = prepare_alg(alg, u0, p, prob)
     _prob = get_concrete_problem(prob, isadaptive(alg); kwargs...)
+    check_prob_alg_pairing(_prob, alg) # use alg for improved inference
     init_call(_prob, alg, args...; kwargs...)
   elseif !isempty(args) && typeof(args[1]) <: DEAlgorithm
     alg = args[1]
+    _alg = prepare_alg(alg, u0, p, prob)
     _prob = get_concrete_problem(prob, isadaptive(alg); kwargs...)
+    check_prob_alg_pairing(_prob, alg)
     init_call(_prob, args...; kwargs...)
   else
     _prob = get_concrete_problem(prob, !(typeof(prob) <: DiscreteProblem); kwargs...)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -227,13 +227,11 @@ end
 function init(prob::DEProblem, args...; kwargs...)
   if haskey(kwargs, :alg) && (isempty(args) || args[1] === nothing)
     alg = kwargs[:alg]
-    _alg = prepare_alg(alg, u0, p, prob)
     _prob = get_concrete_problem(prob, isadaptive(alg); kwargs...)
-    check_prob_alg_pairing(_prob, alg) # use alg for improved inference
+    check_prob_alg_pairing(_prob, alg)
     init_call(_prob, alg, args...; kwargs...)
   elseif !isempty(args) && typeof(args[1]) <: DEAlgorithm
     alg = args[1]
-    _alg = prepare_alg(alg, u0, p, prob)
     _prob = get_concrete_problem(prob, isadaptive(alg); kwargs...)
     check_prob_alg_pairing(_prob, alg)
     init_call(_prob, args...; kwargs...)
@@ -280,7 +278,7 @@ function solve_up(prob::DEProblem, sensealg, u0, p, args...; kwargs...)
     alg = kwargs[:alg]
     _alg = prepare_alg(alg, u0, p, prob) 
     _prob = get_concrete_problem(prob, isadaptive(_alg); u0=u0, p=p, kwargs...)
-    check_prob_alg_pairing(_prob, alg)
+    check_prob_alg_pairing(_prob, alg) # use alg for improved inference
     solve_call(_prob, _alg, args...; kwargs...)
   elseif !isempty(args) && typeof(args[1]) <: DEAlgorithm
     alg = args[1]

--- a/test/downstream/solve_error_handling.jl
+++ b/test/downstream/solve_error_handling.jl
@@ -15,6 +15,7 @@ prob = ODEProblem(f,u0,tspan)
 prob = ODEProblem{false}(f,u0,tspan)
 sol = solve(prob,Tsit5())
 
+@test_throws DiffEqBase.ProblemSolverPairingError solve(prob, DFBDF())
 @test_throws DiffEqBase.NoDefaultAlgorithmError solve(prob,nothing)
 @test_throws DiffEqBase.NonSolverError solve(prob,5.0)
 


### PR DESCRIPTION
```julia
using Sundials, LinearAlgebra

function dfdt!(du, u, p, t)
      du[1] = u[8] / 1.072
      du[2] = u[9] / 0.2638
      du[3] = u[10] / 1.682
      du[4] = u[11] / 0.8365
      du[5] = u[12] / 0.7265
      du[6] = u[2] / 1.304
      du[7] = u[4] / 0.8586
      du[8] = u[10] + u[11] + u[7] - u[9] - u[6]
      du[9] = u[1] - u[3] - u[2]
      du[10] = u[3] - u[5] - u[4]
      du[11] = u[8] + u[9] + u[6] - 1.0 + u[1]
      du[12] = u[11] + u[7] - u[12] - u[5]
      return nothing
end

u0 = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
M = Diagonal([1.,1.,1.,1.,1.,1.,1.,0.,0.,0.,0.,0.])

t1 = [0.0:0.1:10.0;]
tspan = (t1[1], last(t1))

f = ODEFunction(dfdt!, mass_matrix=M)
prob = ODEProblem(f, u0, tspan)
sol = solve(prob, IDA())
```

Old error message: https://discourse.julialang.org/t/modelingtoolkit-vs-plain-differentialequations/81322/10?u=chrisrackauckas

```julia
ERROR: MethodError: no method matching __init(::ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, true, Vector{Float64}, ODEFunction{true, typeof(dfdt!), Diagonal{Float64, Vector{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, ::IDA{:Dense, Nothing, Nothing}, ::Vector{Any}, ::Vector{Any}, ::Vector{Any})
```

etc. New error message:

```julia
julia> sol = solve(prob, IDA())
ERROR: Incompatible problem+solver pairing.
For example, this can occur if an ODE solver is passed with an SDEProblem.
Solvers are only capable of handling specific problem types. Please double
check that the chosen pairing is capable for handling the given problems.

Problem type: ODEProblem
Solver type: IDA
Problem types compatible with the chosen solver: DAEProblem

Stacktrace:
 [1] check_prob_alg_pairing(prob::ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, true, SciMLBase.NullParameters, ODEFunction{true, typeof(dfdt!), Diagonal{Float64, Vector{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, alg::IDA{:Dense, Nothing, Nothing})
   @ DiffEqBase C:\Users\accou\.julia\dev\DiffEqBase\src\solve.jl:505
 [2] solve_up(prob::ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, true, SciMLBase.NullParameters, ODEFunction{true, typeof(dfdt!), Diagonal{Float64, Vector{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, sensealg::Nothing, u0::Vector{Float64}, p::SciMLBase.NullParameters, args::IDA{:Dense, Nothing, Nothing}; kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ DiffEqBase C:\Users\accou\.julia\dev\DiffEqBase\src\solve.jl:270
 [3] solve_up(prob::ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, true, SciMLBase.NullParameters, ODEFunction{true, typeof(dfdt!), Diagonal{Float64, Vector{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, sensealg::Nothing, u0::Vector{Float64}, p::SciMLBase.NullParameters, args::IDA{:Dense, Nothing, Nothing})
   @ DiffEqBase C:\Users\accou\.julia\dev\DiffEqBase\src\solve.jl:260
 [4] solve(prob::ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, true, SciMLBase.NullParameters, ODEFunction{true, typeof(dfdt!), Diagonal{Float64, Vector{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, args::IDA{:Dense, Nothing, Nothing}; sensealg::Nothing, u0::Nothing, p::Nothing, kwargs::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ DiffEqBase C:\Users\accou\.julia\dev\DiffEqBase\src\solve.jl:255
 [5] solve(prob::ODEProblem{Vector{Float64}, Tuple{Float64, Float64}, true, SciMLBase.NullParameters, ODEFunction{true, typeof(dfdt!), Diagonal{Float64, Vector{Float64}}, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, Nothing, typeof(SciMLBase.DEFAULT_OBSERVED), Nothing}, Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, SciMLBase.StandardODEProblem}, args::IDA{:Dense, Nothing, Nothing})
   @ DiffEqBase C:\Users\accou\.julia\dev\DiffEqBase\src\solve.jl:250
 [6] top-level scope
   @ REPL[1]:1
```