### PR TITLE
Throw a high level interpretable error for non-concrete eltype `u0`

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -314,8 +314,8 @@ function solve_call(_prob, args...; merge_callbacks=true, kwargshandle=KeywordAr
   end
 
   checkkwargs(kwargshandle; kwargs...)
-  isdefined(prob, :u0) && !isconcretetype(eltype(prob.u0)) && 
-                          throw(NonConcreteEltypeError(eltype(prob.u0)))
+  isdefined(_prob, :u0) && !isconcretetype(eltype(_prob.u0)) && 
+                          throw(NonConcreteEltypeError(eltype(_prob.u0)))
 
   if hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) && typeof(_prob.f.f) <: EvalFunc
     Base.invokelatest(__solve, _prob, args...; kwargs...)#::T

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -230,6 +230,40 @@ function Base.showerror(io::IO, e::DirectAutodiffError)
   println(io, DIRECT_AUTODIFF_INCOMPATABILITY_MESSAGE)
 end
 
+const NONCONCRETE_ELTYPE_MESSAGE = 
+"""
+Non-concrete element type inside of an `Array` detected.
+Arrays with non-concrete element types, such as 
+`Array{Union{Float32,Float64}}`, are not supported by the 
+differential equation solvers. Anyways, this is bad for
+performance so you don't want to be doing this!
+
+If this was a mistake, promote the element types to be
+all the same. If this was intentional, for example,
+using Unitful.jl with different unit values, then use
+an array type which has fast broadcast support for
+heterogeneous values such as the ArrayPartition
+from RecursiveArrayTools.jl. For example:
+
+```julia
+using RecursiveArrayTools
+x = ArrayPartition([1.0,2.0],[1f0,2f0])
+y = ArrayPartition([3.0,4.0],[3f0,4f0])
+x .+ y # fast, stable, and usable as u0 into DiffEq!
+```
+
+Element type:
+"""
+
+struct NonConcreteEltypeError <: Exception 
+  eltype
+end
+
+function Base.showerror(io::IO, e::NonConcreteEltypeError)
+  print(io, NONCONCRETE_ELTYPE_MESSAGE)
+  print(io,e.eltype)
+end
+
 function init_call(_prob, args...; merge_callbacks=true, kwargshandle=KeywordArgWarn, kwargs...)
 
   if has_kwargs(_prob)
@@ -280,6 +314,8 @@ function solve_call(_prob, args...; merge_callbacks=true, kwargshandle=KeywordAr
   end
 
   checkkwargs(kwargshandle; kwargs...)
+  isdefined(prob, :u0) && !isconcretetype(eltype(prob.u0)) && 
+                          throw(NonConcreteEltypeError(eltype(prob.u0)))
 
   if hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) && typeof(_prob.f.f) <: EvalFunc
     Base.invokelatest(__solve, _prob, args...; kwargs...)#::T

--- a/test/downstream/solve_error_handling.jl
+++ b/test/downstream/solve_error_handling.jl
@@ -21,3 +21,6 @@ sol = solve(prob,Tsit5())
 
 prob = ODEProblem{false}(f,u0,(nothing,nothing))
 @test_throws DiffEqBase.NoTspanError solve(prob,Tsit5())
+
+prob = ODEProblem{false}(f,Any[1.0,1f0],tspan)
+@test_throws DiffEqBase.NonConcreteEltypeError solve(prob,Tsit5())


### PR DESCRIPTION
Just another step on the quest to make things just a bit nicer to use.