### PR TITLE
always print the unrecognized kwargs

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -76,9 +76,10 @@ const KWARGWARN_MESSAGE =
 Unrecognized keyword arguments found. Future versions will error.
 The only allowed keyword arguments to `solve` are: 
 $allowedkeywords
+
 See https://diffeq.sciml.ai/stable/basics/common_solver_opts/ for more details.
 
-Set kwargshandle=KeywordArgError for an error message and more details.
+Set kwargshandle=KeywordArgError for an error message.
 Set kwargshandle=KeywordArgSilent to ignore this message.
 """
 
@@ -87,6 +88,7 @@ const KWARGERROR_MESSAGE =
 Unrecognized keyword arguments found.
 The only allowed keyword arguments to `solve` are: 
 $allowedkeywords
+
 See https://diffeq.sciml.ai/stable/basics/common_solver_opts/ for more details.
 """
 
@@ -98,7 +100,9 @@ function Base.showerror(io::IO, e::CommonKwargError)
   println(io, KWARGERROR_MESSAGE)
   notin = collect(map(x -> x ∉ allowedkeywords, keys(e.kwargs)))
   unrecognized = collect(keys(e.kwargs))[notin]
-  print(io, "Unrecognized keyword arguments: $unrecognized")
+  print(io, "Unrecognized keyword arguments: ")
+  printstyled(io, unrecognized; bold=true, color=:red)
+  print(io, "\n\n")
 end
 
 @enum KeywordArgError KeywordArgWarn KeywordArgSilent
@@ -380,6 +384,10 @@ function checkkwargs(kwargshandle; kwargs...)
       throw(CommonKwargError(kwargs))
     elseif kwargshandle == KeywordArgWarn
       @warn KWARGWARN_MESSAGE
+      unrecognized = setdiff(keys(kwargs), allowedkeywords)
+      print("Unrecognized keyword arguments: ")
+      printstyled(unrecognized; bold=true, color=:red)
+      print("\n\n")
     else
       @assert kwargshandle == KeywordArgSilent
     end


### PR DESCRIPTION
I don't really care about the styling so I'm happy to remove it, but mainly I can't think of a reason why you wouldn't want the warning to show the incorrect kwargs. Also a few readability improvements. 

I didn't want to interpolate into the warning message since it'd have to reallocate the string, so I just print after the warning
```julia 
julia> sol = solve(prob_ode_lotkavoltera, Tsit5())
┌ Warning: Unrecognized keyword arguments found. Future versions will error.
│ The only allowed keyword arguments to `solve` are: 
│ (:dense, :saveat, :save_idxs, :tstops, :d_discontinuities, :save_everystep, :save_on, :save_start, :save_end, :initialize_save, :adaptive, :abstol, :reltol, :dt, :dtmax, :dtmin, :force_dtmin, :internalnorm, :controller, :gamma, :beta1, :beta2, :qmax, :qmin, :qsteady_min, :qsteady_max, :qoldinit, :failfactor, :calck, :alias_u0, :maxiters, :callback, :isoutofdomain, :unstable_check, :verbose, :merge_callbacks, :progress, :progress_steps, :progress_name, :progress_message, :timeseries_errors, :dense_errors, :calculate_errors, :initializealg, :alg, :save_noise, :delta, :seed, :alg_hints, :kwargshandle, :trajectories, :batch_size, :sensealg, :advance_to_tstop, :stop_at_next_tstop, :default_set, :second_time)
│ See https://diffeq.sciml.ai/stable/basics/common_solver_opts/ for more details.
│ 
│ Set kwargshandle=KeywordArgError for an error message and more details.
│ Set kwargshandle=KeywordArgSilent to ignore this message.
└ @ DiffEqBase ~/.julia/packages/DiffEqBase/202zR/src/solve.jl:443
retcode: Success
```
vs 

```julia 
julia> sol = solve(prob_ode_lotkavoltera, Tsit5())
┌ Warning: Unrecognized keyword arguments found. Future versions will error.
│ The only allowed keyword arguments to `solve` are: 
│ (:dense, :saveat, :save_idxs, :tstops, :d_discontinuities, :save_everystep, :save_on, :save_start, :save_end, :initialize_save, :adaptive, :abstol, :reltol, :dt, :dtmax, :dtmin, :force_dtmin, :internalnorm, :controller, :gamma, :beta1, :beta2, :qmax, :qmin, :qsteady_min, :qsteady_max, :qoldinit, :failfactor, :calck, :alias_u0, :maxiters, :callback, :isoutofdomain, :unstable_check, :verbose, :merge_callbacks, :progress, :progress_steps, :progress_name, :progress_message, :timeseries_errors, :dense_errors, :calculate_errors, :initializealg, :alg, :save_noise, :delta, :seed, :alg_hints, :kwargshandle, :trajectories, :batch_size, :sensealg, :advance_to_tstop, :stop_at_next_tstop, :default_set, :second_time)
│ 
│ See https://diffeq.sciml.ai/stable/basics/common_solver_opts/ for more details.
│ 
│ Set kwargshandle=KeywordArgError for an error message.
│ Set kwargshandle=KeywordArgSilent to ignore this message.
└ @ DiffEqBase ~/.julia/dev/DiffEqBase/src/solve.jl:386
Unrecognized keyword arguments: [:foo, :bar]

retcode: Success
```