### PR TITLE
Typo in recommended algorithm Tsti5

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -158,7 +158,7 @@ end
 const NON_SOLVER_MESSAGE = """
                            The arguments to solve are incorrect.
                            The second argument must be a solver choice, `solve(prob,alg)`
-                           where `alg` is a `<: DEAlgorithm`, e.g.. `Tsit5()`. 
+                           where `alg` is a `<: DEAlgorithm`, e.g. `Tsit5()`. 
 
                            Please double check the arguments being sent to the solver.
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -158,7 +158,7 @@ end
 const NON_SOLVER_MESSAGE = """
                            The arguments to solve are incorrect.
                            The second argument must be a solver choice, `solve(prob,alg)`
-                           where `alg` is a `<: DEAlgorithm`, i.e. `Tsit5()`. 
+                           where `alg` is a `<: DEAlgorithm`, e.g.. `Tsit5()`. 
 
                            Please double check the arguments being sent to the solver.
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -158,9 +158,12 @@ end
 const NON_SOLVER_MESSAGE = """
                            The arguments to solve are incorrect.
                            The second argument must be a solver choice, `solve(prob,alg)`
-                           where `alg` is a `<: DEAlgorithm`, i.e. `Tsti5()`.
+                           where `alg` is a `<: DEAlgorithm`, i.e. `Tsit5()`. 
 
                            Please double check the arguments being sent to the solver.
+
+                           You can find the list of available solvers at https://diffeq.sciml.ai/stable/solvers/ode_solve/
+                           and its associated pages.
                            """
 
 struct NonSolverError <: Exception end


### PR DESCRIPTION
Changes `Tsti5()` to `Tsit5()`. I also added a link to the available solvers to be consistent with `NO_DEFAULT_ALGORITHM_MESSAGE`, in case you think that can be useful.