### PR TITLE
diffeqmapreduce for faster anyeltypedual in some situations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.95.2"
+version = "6.95.3"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"


### PR DESCRIPTION
```julia
julia> @time using DiffEqBase, StaticArrays
  7.564427 seconds (10.75 M allocations: 849.099 MiB, 6.27% gc time, 25.67% compilation time: 54% of which was recompilation)

(p1) pkg> st -m DiffEqBase
Status `~/Documents/progwork/julia/env/p1/Manifest.toml`
  [2b5f629d] DiffEqBase v6.95.2

julia> @code_typed DiffEqBase.promote_u0(SA[1.0,2.0], Returns(((Ka = 1.0,CL = 1, Vc = 1.0,))), 1.2)
CodeInfo(
1 ─       goto #4 if not true
2 ─ %2  = %new(DiffEqBase.var"#85#86"{Returns{NamedTuple{(:Ka, :CL, :Vc), Tuple{Float64, Int64, Float64}}}, Int64}, p, 1)::DiffEqBase.var"#85#86"{Returns{NamedTuple{(:Ka, :CL, :Vc), Tuple{Float64, Int64, Float64}}}, Int64}
│   %3  = DiffEqBase.mapreduce::typeof(mapreduce)
│   %4  = DiffEqBase.promote_dual::typeof(DiffEqBase.promote_dual)
│   %5  = invoke Base.:(var"#mapreduce#263")($(QuoteNode(Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}()))::Base.Pairs{Symbol, Union{}, Tuple{}, NamedTuple{(), Tuple{}}}, %3::typeof(mapreduce), %2::Function, %4::Function, (:value,)::Tuple{Symbol})::Any
│   %6  = ForwardDiff.Dual::Type{ForwardDiff.Dual}
│   %7  = (%5 <: %6)::Bool
└──       goto #4 if not %7
3 ─ %9  = Base.broadcasted(%5, u0)::Base.Broadcast.Broadcasted{Style, Nothing} where Style<:Union{Nothing, Base.Broadcast.BroadcastStyle}
│   %10 = Base.Broadcast.instantiate(%9)::Any
│   %11 = Base.Broadcast.copy(%10)::Any
└──       return %11
4 ┄       return u0
) => Any

julia> @benchmark DiffEqBase.promote_u0(SA[1.0,2.0], Returns(((Ka = 1.0,CL = 1, Vc = 1.0,))), 1.2)
BenchmarkTools.Trial: 10000 samples with 9 evaluations.
 Range (min … max):  3.272 μs …   4.913 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.310 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.351 μs ± 112.216 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

  ▁▅███▇▇▅▃▂▁                 ▁▃▃▄▃▃▂▂          ▁             ▃
  █████████████▆▆▅▆▁▄▅▅▁▁▃▁▁▅▇█████████▇▇▇▇▇███████▇▇▇▇████▇▇ █
  3.27 μs      Histogram: log(frequency) by time      3.75 μs <

 Memory estimate: 336 bytes, allocs estimate: 11.
```
PR:
```julia
julia> @time using DiffEqBase, StaticArrays
[ Info: Precompiling DiffEqBase [2b5f629d-d688-5b77-993f-72d75c75574e]
 20.040235 seconds (10.61 M allocations: 845.558 MiB, 1.28% gc time, 9.50% compilation time: 67% of which was recompilation)

julia> @code_typed DiffEqBase.promote_u0(SA[1.0,2.0], Returns(((Ka = 1.0,CL = 1, Vc = 1.0,))), 1.2)
CodeInfo(
1 ─     return u0
) => SVector{2, Float64}

julia> @benchmark DiffEqBase.promote_u0(SA[1.0,2.0], Returns(((Ka = 1.0,CL = 1, Vc = 1.0,))), 1.2)
BenchmarkTools.Trial: 10000 samples with 999 evaluations.
 Range (min … max):  1.745 ns … 27.479 ns  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     8.910 ns              ┊ GC (median):    0.00%
 Time  (mean ± σ):   8.932 ns ±  0.352 ns  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                                           █
  ▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▁▁▁▂▁▁▁▂▂▁▁▁█ ▂
  1.74 ns        Histogram: frequency by time        8.93 ns <

 Memory estimate: 0 bytes, allocs estimate: 0.
```