### PR TITLE
@fastmath sqrt for ODE_DEFAULT_NORM

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -17,7 +17,9 @@ jobs:
         julia-version: [1,1.6]
         os: [ubuntu-latest]
         package:
-          - {user: SciML, repo: DelayDiffEq.jl, group: All}
+          - {user: SciML, repo: DelayDiffEq.jl, group: Interface}
+          - {user: SciML, repo: DelayDiffEq.jl, group: Integrators}
+          - {user: SciML, repo: DelayDiffEq.jl, group: Regression}
           - {user: SciML, repo: DiffEqFlux.jl, group: DiffEqFlux}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceI}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceII}
@@ -28,7 +30,10 @@ jobs:
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: IntegratorsII}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: RegressionI}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: RegressionII}
-          - {user: SciML, repo: StochasticDiffEq.jl, group: All}
+          - {user: SciML, repo: StochasticDiffEq.jl, group: Interface1}
+          - {user: SciML, repo: StochasticDiffEq.jl, group: Interface2}
+          - {user: SciML, repo: StochasticDiffEq.jl, group: Interface3}
+          - {user: SciML, repo: StochasticDiffEq.jl, group: AlgConvergence}
           - {user: SciML, repo: Sundials.jl, group: All}
 
     steps:

--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -26,15 +26,15 @@ end
     @inbounds for i in 2:length(u)
         x += abs2(u[i])
     end
-    sqrt(real(x) / length(u))
+    Base.FastMath.sqrt_fast(real(x) / length(u))
 end
 
 @inline function ODE_DEFAULT_NORM(u::StaticArrays.StaticArray{T},
                                   t) where {T <: Union{AbstractFloat, Complex}}
-    sqrt(real(sum(abs2, u)) / length(u))
+    Base.FastMath.sqrt_fast(real(sum(abs2, u)) / length(u))
 end
 
-@inline ODE_DEFAULT_NORM(u::AbstractArray, t) = sqrt(UNITLESS_ABS2(u) / recursive_length(u))
+@inline ODE_DEFAULT_NORM(u::AbstractArray, t) = Base.FastMath.sqrt_fast(UNITLESS_ABS2(u) / recursive_length(u))
 @inline ODE_DEFAULT_NORM(u, t) = norm(u)
 
 @inline ODE_DEFAULT_ISOUTOFDOMAIN(u, p, t) = false

--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -34,7 +34,9 @@ end
     Base.FastMath.sqrt_fast(real(sum(abs2, u)) / length(u))
 end
 
-@inline ODE_DEFAULT_NORM(u::AbstractArray, t) = Base.FastMath.sqrt_fast(UNITLESS_ABS2(u) / recursive_length(u))
+@inline function ODE_DEFAULT_NORM(u::AbstractArray, t)
+    Base.FastMath.sqrt_fast(UNITLESS_ABS2(u) / recursive_length(u))
+end
 @inline ODE_DEFAULT_NORM(u, t) = norm(u)
 
 @inline ODE_DEFAULT_ISOUTOFDOMAIN(u, p, t) = false


### PR DESCRIPTION
This PR is purely motivated by aesthetics, not benchmarks.

When looking at assembly of an experimental perform_step! function, I thought it'd be prettier without the error check and call to complex domain error.