### PR TITLE
Require v1.8 for no recompile

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -962,18 +962,21 @@ function promote_f(f::F, ::Val{specialize}, u0, p, t) where {F, specialize}
         f = @set f.jac_prototype = similar(f.jac_prototype, uElType)
     end
 
-    f = if f isa ODEFunction && isinplace(f) &&
-           (specialize === SciMLBase.AutoSpecialize ||
-            specialize === SciMLBase.FunctionWrapperSpecialize) &&
-           !(f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper) &&
-           (typeof(u0) <: Vector{Float64} && eltype(t) <: Float64 &&
-            typeof(p) <: Union{SciMLBase.NullParameters, Vector{Float64}})
-        wrapfun_iip(f, (u0, u0, p, t))
+    @static if VERSION >= v"1.8-"
+        f = if f isa ODEFunction && isinplace(f) &&
+            (specialize === SciMLBase.AutoSpecialize ||
+                specialize === SciMLBase.FunctionWrapperSpecialize) &&
+            !(f.f isa FunctionWrappersWrappers.FunctionWrappersWrapper) &&
+            (typeof(u0) <: Vector{Float64} && eltype(t) <: Float64 &&
+                typeof(p) <: Union{SciMLBase.NullParameters, Vector{Float64}})
+            wrapfun_iip(f, (u0, u0, p, t))
+        else
+            f
+        end
+        return f
     else
-        f
+        return f
     end
-
-    return f
 end
 
 function promote_f(f::SplitFunction, ::Val{specialize}, u0, p, t) where {specialize}

--- a/test/downstream/inference.jl
+++ b/test/downstream/inference.jl
@@ -9,6 +9,7 @@ tspan = (0.0, 1.0)
 prob = ODEProblem(lorenz, u0, tspan)
 sol = solve(prob, Tsit5(), save_idxs = 1)
 @inferred solve(prob, Tsit5())
+@inferred solve(prob, Tsit5(), save_idxs = 1)
 @test_broken @inferred remake(prob, u0 = Float32[1.0; 0.0; 0.0])
 @test_broken @inferred solve(prob, Tsit5(), u0 = Float32[1.0; 0.0; 0.0])
 
@@ -22,8 +23,8 @@ end
 @test_broken @inferred solve(prob, Tsit5(), u0 = Float32[1.0; 0.0; 0.0])
 
 prob = ODEProblem(lorenz, Float32[1.0; 0.0; 0.0], tspan)
-sol = solve(prob, Tsit5(), save_idxs = 1)
-solve(prob, Tsit5(), u0 = [1.0; 0.0; 0.0])
+@inferred solve(prob, Tsit5(), save_idxs = 1)
+@test_broken @inferred solve(prob, Tsit5(), u0 = [1.0; 0.0; 0.0])
 remake(prob, u0 = [1.0; 0.0; 0.0])
 
 if VERSION >= v"1.8-"


### PR DESCRIPTION
The specializations required for inference only exist on v1.8+, and the precompile fixes only improve precompilation there too, and so it only makes sense to do the AutoSpecialize on v1.8+. This should fix the v1.6 inference tests