### PR TITLE
fix deprecated call

### DIFF
--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -63,10 +63,12 @@ function (dec::DualEltypeChecker)(::Val{Y}) where {Y}
     anyeltypedual(getproperty(dec.x, Y), dec.counter)
 end
 
-# use `getfield` for `Pairs`, see https://github.com/JuliaLang/julia/pull/39448
-function (dec::DualEltypeChecker{<:Base.Pairs})(::Val{Y}) where {Y}
-    isdefined(dec.x, Y) || return Any
-    anyeltypedual(getfield(dec.x, Y), dec.counter)
+# use `getfield` on `Pairs`, see https://github.com/JuliaLang/julia/pull/39448
+if VERSION >= v"1.7"
+    function (dec::DualEltypeChecker{<:Base.Pairs})(::Val{Y}) where {Y}
+        isdefined(dec.x, Y) || return Any
+        anyeltypedual(getfield(dec.x, Y), dec.counter)
+    end
 end
 
 # Untyped dispatch: catch composite types, check all of their fields

--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -42,7 +42,7 @@ end
 # all be unrolled and optimized away.
 # Being unrolled also means const prop can work for things like
 # `mapreduce(f, op, propertynames(x))`
-# where `f` may call `getproperty` and thus have return type dependent
+# where `f` may call `getfield` and thus have return type dependent
 # on the particular symbol.
 # `mapreduce` hasn't received any such specialization.
 @inline diffeqmapreduce(f::F, op::OP, x::Tuple) where {F, OP} = reduce_tup(op, map(f, x))
@@ -59,7 +59,7 @@ struct DualEltypeChecker{T}
 end
 function (dec::DualEltypeChecker)(::Val{Y}) where {Y}
     isdefined(dec.x, Y) || return Any
-    anyeltypedual(getproperty(dec.x, Y), dec.counter)
+    anyeltypedual(getfield(dec.x, Y), dec.counter)
 end
 
 # Untyped dispatch: catch composite types, check all of their fields

--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -222,3 +222,7 @@ for p in p_possibilities_configs_not_inferred
     u0 = ForwardDiff.Dual(2.0)
     @test DiffEqBase.promote_u0(u0, p, t0) isa ForwardDiff.Dual
 end
+
+# use `getfield` on `Pairs`, see https://github.com/JuliaLang/julia/pull/39448
+VERSION >= v"1.7" && 
+           @test_nowarn DiffEqBase.DualEltypeChecker(pairs((;)), 0)(Val(:data))


### PR DESCRIPTION
Since https://github.com/JuliaLang/julia/pull/39448, `getproperty` has been deprecated in favor of `getfield`.