### PR TITLE
remove unbound type parameter

### DIFF
--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -128,7 +128,7 @@ ZygoteRules.@adjoint function DiffEqBase.EnsembleSolution(sim, time, converged)
                    for j in 1:size(p̄)[end - 1]] for i in 1:size(p̄)[end]]
         (EnsembleSolution(arrarr, 0.0, true), nothing, nothing)
     end
-    function EnsembleSolution_adjoint(p̄::AbstractArray{<:AbstractArray, 1}) where {T}
+    function EnsembleSolution_adjoint(p̄::AbstractArray{<:AbstractArray, 1})
         (EnsembleSolution(p̄, 0.0, true), nothing, nothing)
     end
     function EnsembleSolution_adjoint(p̄::EnsembleSolution)


### PR DESCRIPTION
Unbound type parameters often cause performance issues and run time dispatch.

Issue found using https://github.com/JuliaLang/julia/pull/46608