### PR TITLE
make Distributions a weak dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,6 +32,12 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
+[weakdeps]
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+
+[extensions]
+DistributionsExt = "Distributions"
+
 [compat]
 ArrayInterfaceCore = "0.1.26"
 ChainRulesCore = "1"
@@ -59,6 +65,7 @@ julia = "1.6"
 
 [extras]
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
@@ -70,4 +77,4 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Distributed", "LabelledArrays", "ForwardDiff", "InteractiveUtils", "Plots", "Pkg", "Random", "SafeTestsets", "Statistics", "Test"]
+test = ["Distributed", "LabelledArrays", "ForwardDiff", "InteractiveUtils", "Plots", "Pkg", "Random", "SafeTestsets", "Statistics", "Test", "Distributions"]

--- a/ext/DistributionsExt.jl
+++ b/ext/DistributionsExt.jl
@@ -1,0 +1,8 @@
+module DistributionsExt
+
+using Distributions, DiffEqBase
+
+DiffEqBase.handle_distribution_u0(_u0::Distributions.Sampleable) = rand(_u0)
+DiffEqBase.isdistribution(_u0::Distributions.Sampleable) = true
+
+end

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -22,7 +22,6 @@ using FastBroadcast: @.., True, False
 
 using Static: reduce_tup
 
-import Distributions
 import ChainRulesCore
 import RecursiveArrayTools
 import SparseArrays
@@ -149,4 +148,7 @@ export SensitivityADPassThrough
 
 export KeywordArgError, KeywordArgWarn, KeywordArgSilent
 
+if !isdefined(Base, :get_extension)
+  include("../ext/DistributionsExt.jl")
+end
 end # module

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -149,6 +149,6 @@ export SensitivityADPassThrough
 export KeywordArgError, KeywordArgWarn, KeywordArgSilent
 
 if !isdefined(Base, :get_extension)
-  include("../ext/DistributionsExt.jl")
+    include("../ext/DistributionsExt.jl")
 end
 end # module

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1082,8 +1082,6 @@ function get_concrete_p(prob, kwargs)
 end
 
 handle_distribution_u0(_u0) = _u0
-handle_distribution_u0(_u0::Distributions.Sampleable) = rand(_u0)
-isdistribution(_u0::Distributions.Sampleable) = true
 
 eval_u0(u0::Function) = true
 eval_u0(u0) = false


### PR DESCRIPTION
On 1.9, this saves roughly .5 seconds. We also should do this for chainrules, but I'll leave that for another PR.

Before
```

julia> @time @eval using DiffEqBase
  1.914418 seconds (6.02 M allocations: 432.638 MiB, 6.05% gc time, 16.83% compilation time: <1% of which was recompilation)
```
After
```
julia> @time @eval using DiffEqBase
  1.516961 seconds (4.86 M allocations: 365.564 MiB, 5.58% gc time, 18.51% compilation time: <1% of which was recompilation)
```
