### PR TITLE
allow initing and solving with u0=nothing

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -93,7 +93,7 @@ using SciMLBase: @def, DEIntegrator, DEProblem, AbstractSciMLOperator,
                  isadaptive, isdiscrete, has_syms, AbstractAnalyticalSolution,
                  RECOMPILE_BY_DEFAULT, wrap_sol, has_destats
 
-import SciMLBase: solve, init, solve!, __init, __solve, update_coefficients!,
+import SciMLBase: solve, init, step!, solve!, __init, __solve, update_coefficients!,
                   update_coefficients, isadaptive, wrapfun_oop, wrapfun_iip,
                   unwrap_fw, promote_tspan, set_u!, set_t!, set_ut!
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -418,7 +418,7 @@ function init_call(_prob, args...; merge_callbacks = true, kwargshandle = Keywor
 
     checkkwargs(kwargshandle; kwargs...)
 
-    if hasfield(typeof(_prob), :u0) && isnothing(_prob.u0)
+    if _prob isa DEProblem && isnothing(_prob.u0)
         build_null_integrator(_prob, args...; kwargs...)
     elseif hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
            typeof(_prob.f.f) <: EvalFunc
@@ -524,14 +524,15 @@ function build_null_integrator(prob::DEProblem, args...;
                                kwargs...)
     @show args, kwargs
     sol = solve(prob, args...; kwargs...)
-    return NullODEIntegrator{isinplace(prob), typeof(prob), eltype(prob.tspan), typeof(sol)}(nothing,
-                                                                                            nothing,
-                                                                                            first(prob.tspan),
-                                                                                            prob,
-                                                                                            sol)
+    return NullODEIntegrator{isinplace(prob), typeof(prob), eltype(prob.tspan), typeof(sol)
+                             }(nothing,
+                               nothing,
+                               first(prob.tspan),
+                               prob,
+                               sol)
 end
 solve!(integ::NullODEIntegrator) = integ.sol
-function step!(integ::NullODEIntegrator, dt=nothing, stop_at_tdt=false)
+function step!(integ::NullODEIntegrator, dt = nothing, stop_at_tdt = false)
     if !isnothing(dt)
         integ.t += dt
     else

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -512,12 +512,15 @@ function solve_call(_prob, args...; merge_callbacks = true, kwargshandle = Keywo
     end
 end
 
-mutable struct NullODEIntegrator{ProbType, AlgType}
+mutable struct NullODEIntegrator{Alg, IIP, ProbType, T}<:AbstractODEIntegrator{Alg, IIP, Nothing, T}
+    alg::Alg
+    du::Nothing
+    u::Nothing
+    t::T
     prob::ProbType
-    alg::AlgType
 end
 function build_null_integrator(prob::DEProblem, alg, args...; kwargs...)
-    return NullODEIntegrator(prob, alg)
+    return NullODEIntegrator{typeof(alg), isinplace(prob), typeof(prob), eltype(prob.tspan)}(alg, nothing, nothing, first(prob.tspan), prob)
 end
 function solve!(integ::NullODEIntegrator)
     return build_null_solution(integ.prob, integ.alg)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -512,7 +512,8 @@ function solve_call(_prob, args...; merge_callbacks = true, kwargshandle = Keywo
     end
 end
 
-mutable struct NullODEIntegrator{Alg, IIP, ProbType, T}<:AbstractODEIntegrator{Alg, IIP, Nothing, T}
+mutable struct NullODEIntegrator{Alg, IIP, ProbType, T} <:
+               AbstractODEIntegrator{Alg, IIP, Nothing, T}
     alg::Alg
     du::Nothing
     u::Nothing
@@ -520,7 +521,8 @@ mutable struct NullODEIntegrator{Alg, IIP, ProbType, T}<:AbstractODEIntegrator{A
     prob::ProbType
 end
 function build_null_integrator(prob::DEProblem, alg, args...; kwargs...)
-    return NullODEIntegrator{typeof(alg), isinplace(prob), typeof(prob), eltype(prob.tspan)}(alg, nothing, nothing, first(prob.tspan), prob)
+    return NullODEIntegrator{typeof(alg), isinplace(prob), typeof(prob), eltype(prob.tspan)
+                             }(alg, nothing, nothing, first(prob.tspan), prob)
 end
 function solve!(integ::NullODEIntegrator)
     return build_null_solution(integ.prob, integ.alg)

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -514,8 +514,8 @@ end
 
 mutable struct NullODEIntegrator{IIP, ProbType, T, SolType} <:
                AbstractODEIntegrator{Nothing, IIP, Nothing, T}
-    du::Nothing
-    u::Nothing
+    du::Vector{Float64}
+    u::Vector{Float64}
     t::T
     prob::ProbType
     sol::SolType
@@ -524,13 +524,16 @@ function build_null_integrator(prob::DEProblem, args...;
                                kwargs...)
     sol = solve(prob, args...; kwargs...)
     return NullODEIntegrator{isinplace(prob), typeof(prob), eltype(prob.tspan), typeof(sol)
-                             }(nothing,
-                               nothing,
+                             }(Float64[],
+                               Float64[],
                                first(prob.tspan),
                                prob,
                                sol)
 end
-solve!(integ::NullODEIntegrator) = integ.sol
+function solve!(integ::NullODEIntegrator)
+    integ.t = integ.sol.t[end]
+    return nothing
+end
 function step!(integ::NullODEIntegrator, dt = nothing, stop_at_tdt = false)
     if !isnothing(dt)
         integ.t += dt

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -418,7 +418,9 @@ function init_call(_prob, args...; merge_callbacks = true, kwargshandle = Keywor
 
     checkkwargs(kwargshandle; kwargs...)
 
-    if hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
+    if isnothing(_prob.u0)
+        build_null_integrator(_prob, args...; kwargs...)
+    elseif hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
        typeof(_prob.f.f) <: EvalFunc
         Base.invokelatest(__init, _prob, args...; kwargs...)#::T
     else
@@ -508,6 +510,17 @@ function solve_call(_prob, args...; merge_callbacks = true, kwargshandle = Keywo
     else
         __solve(_prob, args...; kwargs...)#::T
     end
+end
+
+mutable struct NullODEIntegrator{ProbType, AlgType}
+    prob::ProbType
+    alg::AlgType
+end
+function build_null_integrator(prob::DEProblem, alg, args...; kwargs...)
+    return NullODEIntegrator(prob, alg)
+end
+function solve!(integ::NullODEIntegrator)
+    return build_null_solution(integ.prob, integ.alg)
 end
 
 function build_null_solution(prob::DEProblem, args...;

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -418,8 +418,7 @@ function init_call(_prob, args...; merge_callbacks = true, kwargshandle = Keywor
 
     checkkwargs(kwargshandle; kwargs...)
 
-    if _prob isa Union{ODEProblem, DAEProblem} && isdefined(_prob, :u0) &&
-       isnothing(_prob.u0)
+    if _prob isa Union{ODEProblem, DAEProblem} && isnothing(_prob.u0)
         build_null_integrator(_prob, args...; kwargs...)
     elseif hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
            typeof(_prob.f.f) <: EvalFunc
@@ -523,7 +522,6 @@ mutable struct NullODEIntegrator{IIP, ProbType, T, SolType} <:
 end
 function build_null_integrator(prob::DEProblem, args...;
                                kwargs...)
-    @show args, kwargs
     sol = solve(prob, args...; kwargs...)
     return NullODEIntegrator{isinplace(prob), typeof(prob), eltype(prob.tspan), typeof(sol)
                              }(nothing,

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -418,7 +418,8 @@ function init_call(_prob, args...; merge_callbacks = true, kwargshandle = Keywor
 
     checkkwargs(kwargshandle; kwargs...)
 
-    if _prob isa DEProblem && isdefined(_prob, :u0) &&isnothing(_prob.u0)
+    if _prob isa Union{ODEProblem, DAEProblem} && isdefined(_prob, :u0) &&
+       isnothing(_prob.u0)
         build_null_integrator(_prob, args...; kwargs...)
     elseif hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
            typeof(_prob.f.f) <: EvalFunc
@@ -905,7 +906,7 @@ problems.
 #### Error Control
 
 * `abstol`: Absolute tolerance.
-* `reltol`: Relative tolerance. 
+* `reltol`: Relative tolerance.
 
 ### Miscellaneous
 

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -418,10 +418,10 @@ function init_call(_prob, args...; merge_callbacks = true, kwargshandle = Keywor
 
     checkkwargs(kwargshandle; kwargs...)
 
-    if isnothing(_prob.u0)
+    if hasfield(typeof(_prob), :u0) && isnothing(_prob.u0)
         build_null_integrator(_prob, args...; kwargs...)
     elseif hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
-       typeof(_prob.f.f) <: EvalFunc
+           typeof(_prob.f.f) <: EvalFunc
         Base.invokelatest(__init, _prob, args...; kwargs...)#::T
     else
         __init(_prob, args...; kwargs...)#::T

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -418,7 +418,7 @@ function init_call(_prob, args...; merge_callbacks = true, kwargshandle = Keywor
 
     checkkwargs(kwargshandle; kwargs...)
 
-    if _prob isa DEProblem && isnothing(_prob.u0)
+    if _prob isa DEProblem && isdefined(_prob, :u0) &&isnothing(_prob.u0)
         build_null_integrator(_prob, args...; kwargs...)
     elseif hasfield(typeof(_prob), :f) && hasfield(typeof(_prob.f), :f) &&
            typeof(_prob.f.f) <: EvalFunc

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -20,8 +20,11 @@ for kwargs in [
 ]
     sol = solve(prob, kwargs...)
     init_sol = solve!(init(prob, kwargs...))
+    step_sol = step!(init(prob, kwargs...), prob.tspan[end]-prob.tspan[begin])
     @test sol.u == init_sol.u
     @test sol.t == init_sol.t
+    @test sol.u == step_sol.u
+    @test sol.t == step_sol.t
 end
 
 @variables t x y

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -22,11 +22,11 @@ for kwargs in [
     init_integ = init(prob, kwargs...)
     solve!(init_integ)
     step_integ = init(prob, kwargs...)
-    step_sol = step!(step_integ, prob.tspan[end] - prob.tspan[begin])
-    @test sol.u == init_integ.u
-    @test sol.t == init_integ.t
-    @test sol.u == step_integ.u
-    @test sol.t == step_integ.t
+    step!(step_integ, prob.tspan[end] - prob.tspan[begin])
+    @test sol.u[end] == init_integ.u
+    @test sol.t[end] == init_integ.t
+    @test sol.u[end] == step_integ.u
+    @test sol.t[end] == step_integ.t
 end
 
 @variables t x y

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -13,6 +13,11 @@ sol = solve(prob, Tsit5())
 @test sol[x] == [0.0, 0.0]
 @test sol[y] == [0.0, 0.0]
 
+integ = init(prob, Tsit5())
+sol = solve!(integ)
+@test sol[x] == [0.0, 0.0]
+@test sol[y] == [0.0, 0.0]
+
 @variables t x y
 eqs = [0 ~ x - y
        0 ~ y - x]

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -13,10 +13,16 @@ sol = solve(prob, Tsit5())
 @test sol[x] == [0.0, 0.0]
 @test sol[y] == [0.0, 0.0]
 
-integ = init(prob, Tsit5())
-sol = solve!(integ)
-@test sol[x] == [0.0, 0.0]
-@test sol[y] == [0.0, 0.0]
+for kwargs in [
+    Dict(:saveat => 0:0.1:1),
+    Dict(:save_start => false),
+    Dict(:save_end => false),
+]
+    sol = solve(prob, kwargs...)
+    init_sol = solve!(init(prob, kwargs...))
+    @test sol.u == init_sol.u
+    @test sol.t == init_sol.t
+end
 
 @variables t x y
 eqs = [0 ~ x - y

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -19,12 +19,14 @@ for kwargs in [
     Dict(:save_end => false),
 ]
     sol = solve(prob, kwargs...)
-    init_sol = solve!(init(prob, kwargs...))
-    step_sol = step!(init(prob, kwargs...), prob.tspan[end] - prob.tspan[begin])
-    @test sol.u == init_sol.u
-    @test sol.t == init_sol.t
-    @test sol.u == step_sol.u
-    @test sol.t == step_sol.t
+    init_integ = init(prob, kwargs...)
+    solve!(init_integ)
+    step_integ = init(prob, kwargs...)
+    step_sol = step!(step_integ, prob.tspan[end] - prob.tspan[begin])
+    @test sol.u == init_integ.u
+    @test sol.t == init_integ.t
+    @test sol.u == step_integ.u
+    @test sol.t == step_integ.t
 end
 
 @variables t x y

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -20,7 +20,7 @@ for kwargs in [
 ]
     sol = solve(prob, kwargs...)
     init_sol = solve!(init(prob, kwargs...))
-    step_sol = step!(init(prob, kwargs...), prob.tspan[end]-prob.tspan[begin])
+    step_sol = step!(init(prob, kwargs...), prob.tspan[end] - prob.tspan[begin])
     @test sol.u == init_sol.u
     @test sol.t == init_sol.t
     @test sol.u == step_sol.u


### PR DESCRIPTION
Take 2 of https://github.com/SciML/OrdinaryDiffEq.jl/pull/1818 This time it works with external solvers. @ChrisRackauckas how should I add a test for this? I can't `init` a problem within DiffEqBase since none of the algs are defined.