### PR TITLE
Add alg_order method

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -151,4 +151,9 @@ export KeywordArgError, KeywordArgWarn, KeywordArgSilent
 if !isdefined(Base, :get_extension)
     include("../ext/DistributionsExt.jl")
 end
+
+function alg_order(alg::AbstractODEAlgorithm)
+    error("Order is not defined for this algorithm")
+end
+
 end # module


### PR DESCRIPTION
This PR copies the `alg_order` method definition from OrdinaryDiffEq.jl, so that it can be extended from DiffEqBase. cf: https://github.com/SciML/OrdinaryDiffEq.jl/issues/1825.

I realized when making this PR, that we could move this all the way down to SciMLBase if that's preferred. I'm not super familiar with what sort of things are being separated