### PR TITLE
Fix ODE_DEFAULT_NORM for Static Arrays

### DIFF
--- a/ext/GeneralizedGeneratedExt.jl
+++ b/ext/GeneralizedGeneratedExt.jl
@@ -1,7 +1,8 @@
 module GeneralizedGeneratedExt
 
 using DiffEqBase
-isdefined(Base, :get_extension) ? (using GeneralizedGenerated) : (using ..GeneralizedGenerated)
+isdefined(Base, :get_extension) ? (using GeneralizedGenerated) :
+(using ..GeneralizedGenerated)
 
 function SciMLBase.numargs(::GeneralizedGenerated.RuntimeFn{Args}) where {Args}
     GeneralizedGenerated.from_type(Args) |> length

--- a/ext/MonteCarloMeasurementsExt.jl
+++ b/ext/MonteCarloMeasurementsExt.jl
@@ -2,7 +2,8 @@ module MonteCarloMeasurementsExt
 
 using DiffEqBase
 import DiffEqBase: value
-isdefined(Base, :get_extension) ? (using MonteCarloMeasurements) : (using ..MonteCarloMeasurements)
+isdefined(Base, :get_extension) ? (using MonteCarloMeasurements) :
+(using ..MonteCarloMeasurements)
 
 function DiffEqBase.promote_u0(u0::AbstractArray{<:MonteCarloMeasurements.AbstractParticles
                                                  },

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -1,8 +1,8 @@
 module DiffEqBase
 
 if !isdefined(Base, :get_extension)
-  using Requires
-end 
+    using Requires
+end
 
 using ArrayInterfaceCore
 

--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -29,7 +29,7 @@ end
     Base.FastMath.sqrt_fast(real(x) / max(length(u), 1))
 end
 
-@inline function ODE_DEFAULT_NORM(u::StaticArrays.StaticArray{T},
+@inline function ODE_DEFAULT_NORM(u::StaticArrays.StaticArray{<:Tuple, T},
                                   t) where {T <: Union{AbstractFloat, Complex}}
     Base.FastMath.sqrt_fast(real(sum(abs2, u)) / max(length(u), 1))
 end

--- a/src/init.jl
+++ b/src/init.jl
@@ -16,20 +16,12 @@ end
 
 function __init__()
     @static if !isdefined(Base, :get_extension)
-        @require Measurements="eff96d63-e80a-5855-80a2-b1b0885c5ab7" begin
-            include("../ext/MeasurementsExt.jl")
-        end
+        @require Measurements="eff96d63-e80a-5855-80a2-b1b0885c5ab7" begin include("../ext/MeasurementsExt.jl") end
 
-        @require MonteCarloMeasurements="0987c9cc-fe09-11e8-30f0-b96dd679fdca" begin
-            include("../ext/MonteCarloMeasurementsExt.jl")
-        end
+        @require MonteCarloMeasurements="0987c9cc-fe09-11e8-30f0-b96dd679fdca" begin include("../ext/MonteCarloMeasurementsExt.jl") end
 
-        @require Unitful="1986cc42-f94f-5a68-af5c-568840ba703d" begin
-            include("../ext/UnitfulExt.jl")
-        end
+        @require Unitful="1986cc42-f94f-5a68-af5c-568840ba703d" begin include("../ext/UnitfulExt.jl") end
 
-        @require GeneralizedGenerated="6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb" begin
-            include("../ext/GeneralizedGeneratedExt.jl")
-        end
+        @require GeneralizedGenerated="6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb" begin include("../ext/GeneralizedGeneratedExt.jl") end
     end
 end

--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, CUDA, LinearAlgebra, Test
+using OrdinaryDiffEq, CUDA, LinearAlgebra, Test, StaticArrays
 function f(u, p, t)
     A * u
 end
@@ -58,3 +58,14 @@ f_complex(u, nothing, t) = 5.0f-1 .* u
 u0 = cu(rand(32, 32) .+ 1im * rand(32, 32));
 prob = ODEProblem(f_complex, u0, (0.0f0, 1.0f0))
 @test_nowarn sol = solve(prob, Tsit5())
+
+# Calculating norm of Static Arrays in GPU kernel DiffEqBase.jl#864
+
+function test_SA_norm(u::T) where {T <: AbstractArray}
+    @cushow DiffEqBase.ODE_DEFAULT_NORM(u, 1.0)
+    return nothing
+end
+
+u = @SVector rand(100)
+
+@testset "Static arrays norm on GPU" begin @cuda test_SA_norm(u) end


### PR DESCRIPTION
Using Static Arrays in `ODE_DEFAULT_NORM` wasn't hitting the correct dispatch:

```
using StaticArrays, DiffEqBase, Cthulhu
tmp = @SArray rand(10)
@descend DiffEqBase.ODE_DEFAULT_NORM(tmp, 1.0)
```
```
ODE_DEFAULT_NORM(u::AbstractArray, t) in DiffEqBase at /home/gridsan/utkarsh/.julia/dev/DiffEqBase/src/common_defaults.jl:37
   ∘ ─ %0 = invoke ODE_DEFAULT_NORM(::SVector{100, Float64},::Float64)::Float64
38 1 ─ %1 = invoke Base.var"#mapreduce##kw"()($(QuoteNode((init = 0.0,)))::NamedTuple{(:init,), Tuple{Float64}}, DiffEqBase.mapreduce::typeof(mapreduce), DiffEqBase.UNITLESS_ABS2::Function, DiffEqBase.abs2_and_sum::Function, u::SVector{100, Float64})::Float64
```

Apparently, this caused problems with using the method in https://github.com/SciML/DiffEqGPU.jl

```
using DiffEqBase, CUDA, StaticArrays
function test(u)
  @cushow DiffEqBase.ODE_DEFAULT_NORM(u, 1.0f0)
  return
end

tmp = @SArray rand(10)
@cuda test(tmp) # works

tmp = @SArray rand(100)
@cuda test(tmp) #fails, causes some dynamic fn invocation
```