### PR TITLE
Don't return NaN norm when only partials contain NaNs

### DIFF
--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -252,7 +252,11 @@ value(x::ForwardDiff.Dual) = value(ForwardDiff.value(x))
 @inline fastpow(x::ForwardDiff.Dual, y::ForwardDiff.Dual) = x^y
 
 sse(x::Number) = x^2
-sse(x::ForwardDiff.Dual) = sse(ForwardDiff.value(x)) + sum(sse, ForwardDiff.partials(x))
+function sse(x::ForwardDiff.Dual)
+    primal_norm = sse(ForwardDiff.value(x))
+    partial_norm = sum(x -> isnan(x) ? zero(x) : sse(x), ForwardDiff.partials(x))
+    primal_norm + partial_norm
+end
 totallength(x::Number) = 1
 function totallength(x::ForwardDiff.Dual)
     totallength(ForwardDiff.value(x)) + sum(totallength, ForwardDiff.partials(x))


### PR DESCRIPTION
It's somewhat common to have `NaN`s show up in the partials from the RHS function, we should not poison the internal norm because of that.