### PR TITLE
fix dual detection inference specification for v1.9

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -525,7 +525,8 @@ end
 function build_null_integrator(prob::DEProblem, args...;
                                kwargs...)
     sol = solve(prob, args...; kwargs...)
-    return NullODEIntegrator{isinplace(prob), typeof(prob), eltype(prob.tspan), typeof(sol), typeof(prob.f), typeof(prob.p)
+    return NullODEIntegrator{isinplace(prob), typeof(prob), eltype(prob.tspan), typeof(sol),
+                             typeof(prob.f), typeof(prob.p)
                              }(Float64[],
                                Float64[],
                                first(prob.tspan),

--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -128,9 +128,9 @@ p_possibilities_uninferrred = [
     (; x = Vector{Float64}(undef, 2), y = [[MyStruct3(ForwardDiff.Dual(2.0))]]),
     (; x = Matrix{Any}(undef, 2, 2), y = [[MyStruct3(ForwardDiff.Dual(2.0))]]),
 ]
-VERSION >= v"1.9" && 
-    push!(p_possibilities_uninferrred, Returns((a = 2, b = 1.3, c = ForwardDiff.Dual(2.0f0))))
-
+VERSION >= v"1.9" &&
+    push!(p_possibilities_uninferrred,
+          Returns((a = 2, b = 1.3, c = ForwardDiff.Dual(2.0f0))))
 
 for p in p_possibilities_uninferrred
     @show p

--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -85,7 +85,7 @@ p_possibilities17 = [
     (Mod, ForwardDiff.Dual(2.0)), (() -> 2.0, ForwardDiff.Dual(2.0)),
     (Base.pointer([2.0]), ForwardDiff.Dual(2.0)),
 ]
-VERSION >= v"1.7" &&
+VERSION >= v"1.7" && VERSION < v"1.9" &&
     push!(p_possibilities17, Returns((a = 2, b = 1.3, c = ForwardDiff.Dual(2.0f0))))
 
 for p in p_possibilities17
@@ -128,6 +128,9 @@ p_possibilities_uninferrred = [
     (; x = Vector{Float64}(undef, 2), y = [[MyStruct3(ForwardDiff.Dual(2.0))]]),
     (; x = Matrix{Any}(undef, 2, 2), y = [[MyStruct3(ForwardDiff.Dual(2.0))]]),
 ]
+VERSION >= v"1.9" && 
+    push!(p_possibilities_uninferrred, Returns((a = 2, b = 1.3, c = ForwardDiff.Dual(2.0f0))))
+
 
 for p in p_possibilities_uninferrred
     @show p


### PR DESCRIPTION
This is a completely harmless change, just the tests are for inference of everything and the inference of one item seems to have changed.