### PR TITLE
Add a result with state stored for better handling of non linear solvers

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.125.1"
+version = "6.126.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -165,7 +165,7 @@ export SensitivityADPassThrough
 
 export NLSolveTerminationMode,
     NLSolveSafeTerminationOptions, NLSolveTerminationCondition,
-    NLSolveSafeTerminationResult
+    NLSolveSafeTerminationResult, NLSolveSafeTerminationResultWithState
 
 export KeywordArgError, KeywordArgWarn, KeywordArgSilent
 

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -165,7 +165,7 @@ export SensitivityADPassThrough
 
 export NLSolveTerminationMode,
     NLSolveSafeTerminationOptions, NLSolveTerminationCondition,
-    NLSolveSafeTerminationResult, NLSolveSafeTerminationResultWithState
+    NLSolveSafeTerminationResult
 
 export KeywordArgError, KeywordArgWarn, KeywordArgSilent
 


### PR DESCRIPTION
The initial implementation was based on the version in DEQs.jl. But DEQs.jl stored the solver history, which means returning just the best index was good enough. But to generically handle NonlinearSolve.jl, we will also have to store the state.

See https://github.com/avik-pal/BatchedNonlinearSolve.jl/blob/5ff8656e82348e587e2a7645b76c9cf6608e3712/src/raphson.jl#L36 where I am testing out some aspects before moving stuff to NonlinearSolve.