### PR TITLE
Fix reversed time callback detection failure

### DIFF
--- a/src/internal_falsi.jl
+++ b/src/internal_falsi.jl
@@ -34,60 +34,64 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem, alg::InternalFalsi, arg
             right = right)
     end
 
-    i = 1
-    if !iszero(fr)
-        using_falsi_steps = true
-        while i < maxiters
-            # First, perform a regula falsi iteration
-            if using_falsi_steps
-                if nextfloat_tdir(left, prob.tspan...) == right
-                    return SciMLBase.build_solution(prob, alg, left, fl;
-                        retcode = ReturnCode.FloatingPointLimit,
-                        left = left, right = right)
-                end
-                mid = (fr * left - fl * right) / (fr - fl)
-                for i in 1:10
-                    mid = max_tdir(left, prevfloat_tdir(mid, prob.tspan...), prob.tspan...)
-                end
-                if mid == right || mid == left
-                    using_falsi_steps = false
-                    continue
-                end
-                fm = f(mid)
-                if iszero(fm)
-                    right = mid
-                    using_falsi_steps = false
-                    continue
-                end
-                if sign(fl) == sign(fm)
-                    fl = fm
-                    left = mid
-                else
-                    fr = fm
-                    right = mid
-                end
-                i += 1
-            end
+    if iszero(fr)
+        return SciMLBase.build_solution(prob, alg, right, fr;
+        retcode = ReturnCode.ExactSolutionLeft, left = left,
+        right = right)
+    end
 
-            # Then, perform a bisection iteration
-            mid = (left + right) / 2
-            (mid == left || mid == right) &&
+    i = 1
+    using_falsi_steps = true
+    while i < maxiters
+        # First, perform a regula falsi iteration
+        if using_falsi_steps
+            if nextfloat_tdir(left, prob.tspan...) == right
                 return SciMLBase.build_solution(prob, alg, left, fl;
                     retcode = ReturnCode.FloatingPointLimit,
                     left = left, right = right)
+            end
+            mid = (fr * left - fl * right) / (fr - fl)
+            for i in 1:10
+                mid = max_tdir(left, prevfloat_tdir(mid, prob.tspan...), prob.tspan...)
+            end
+            if mid == right || mid == left
+                using_falsi_steps = false
+                continue
+            end
             fm = f(mid)
             if iszero(fm)
                 right = mid
-                fr = fm
-            elseif sign(fm) == sign(fl)
-                left = mid
+                using_falsi_steps = false
+                continue
+            end
+            if sign(fl) == sign(fm)
                 fl = fm
+                left = mid
             else
-                right = mid
                 fr = fm
+                right = mid
             end
             i += 1
         end
+
+        # Then, perform a bisection iteration
+        mid = (left + right) / 2
+        (mid == left || mid == right) &&
+            return SciMLBase.build_solution(prob, alg, left, fl;
+                retcode = ReturnCode.FloatingPointLimit,
+                left = left, right = right)
+        fm = f(mid)
+        if iszero(fm)
+            right = mid
+            fr = fm
+        elseif sign(fm) == sign(fl)
+            left = mid
+            fl = fm
+        else
+            right = mid
+            fr = fm
+        end
+        i += 1
     end
 
     return SciMLBase.build_solution(prob, alg, left, fl; retcode = ReturnCode.MaxIters,

--- a/src/internal_itp.jl
+++ b/src/internal_itp.jl
@@ -29,7 +29,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem{IP, Tuple{T,T}}, alg::In
     k1 = alg.k1
     k2 = alg.k2
     n0 = alg.n0
-    n_h = ceil(log2((right - left) / (2 * ϵ)))
+    n_h = ceil(log2(abs(right - left) / (2 * ϵ)))
     mid = (left + right) / 2
     x_f = (fr * left - fl * right) / (fr - fl)
     xt = left
@@ -64,8 +64,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem{IP, Tuple{T,T}}, alg::In
         end
 
         ## Update ##
-        tmax = max(left, right)
-        tmin = min(left, right)
+        tmin, tmax = minmax(left, right)
         xp >= tmax && (xp = prevfloat(tmax))
         xp <= tmin && (xp = nextfloat(tmin))
         yp = f(xp)

--- a/test/internal_rootfinder.jl
+++ b/test/internal_rootfinder.jl
@@ -3,12 +3,13 @@ using DiffEqBase: InternalFalsi, InternalITP, IntervalNonlinearProblem
 using ForwardDiff
 
 for Rootfinder in (InternalFalsi, InternalITP)
+    rf = Rootfinder()
     # From SimpleNonlinearSolve
     f = (u, p) -> u * u - p
     tspan = (1.0, 20.0)
     g = function (p)
         probN = IntervalNonlinearProblem{false}(f, typeof(p).(tspan), p)
-        sol = solve(probN, Rootfinder())
+        sol = solve(probN, rf)
         return sol.u
     end
 
@@ -20,5 +21,19 @@ for Rootfinder in (InternalFalsi, InternalITP)
     # https://github.com/SciML/DiffEqBase.jl/issues/916 
     inp = IntervalNonlinearProblem((t, p) -> min(-1.0 + 0.001427344607477125 * t, 1e-9),
                                    (699.0079267259368, 700.6176418816023))
-    @test solve(inp, Rootfinder()).u ≈ 700.6016590257979
+    @test solve(inp, rf).u ≈ 700.6016590257979
+
+    # Flipped signs & reversed tspan test for bracketing algorithms
+    f1(u, p) = u * u - p
+    f2(u, p) = p - u * u
+    for p in 1:4
+        inp1 = IntervalNonlinearProblem(f1, (1.0, 2.0), p)
+        inp2 = IntervalNonlinearProblem(f2, (1.0, 2.0), p)
+        inp3 = IntervalNonlinearProblem(f1, (2.0, 1.0), p)
+        inp4 = IntervalNonlinearProblem(f2, (2.0, 1.0), p)
+        @test abs.(solve(inp1, rf).u) ≈ sqrt.(p)
+        @test abs.(solve(inp2, rf).u) ≈ sqrt.(p)
+        @test abs.(solve(inp3, rf).u) ≈ sqrt.(p)
+        @test abs.(solve(inp4, rf).u) ≈ sqrt.(p)
+    end
 end


### PR DESCRIPTION
The new event time rootfinder fails with reverse-time problems; this PR fixes it. 