### PR TITLE
deprecate stats

### DIFF
--- a/src/stats.jl
+++ b/src/stats.jl
@@ -39,6 +39,7 @@ mutable struct Stats
 end
 
 Base.@deprecate_binding DEStats Stats false
+Base.deprecate(@__MODULE__, :Stats)
 
 Stats(x::Int = -1) = Stats(x, x, x, x, x, x, x, x, x, x, 0.0)
 


### PR DESCRIPTION
This is getting moved to SciMLBase. I'm not sure if this is the correct way to mark it deprecated. It seems `@deprecate_moved` seems close but makes the current binding error. `@deprecate_binding` actually requires the new symbol to exist.  Hum.