### PR TITLE
`dualT4` should not be promoted with `T` since `T` might already be a dual

### DIFF
--- a/src/norecompile.jl
+++ b/src/norecompile.jl
@@ -57,13 +57,11 @@ function wrapfun_iip(ff,
     dualT = dualgen(T)
     dualT1 = ArrayInterface.promote_eltype(T1, dualT)
     dualT2 = ArrayInterface.promote_eltype(T2, dualT)
-    dualT4 = dualgen(T4)
-    dualT4_T = promote_dual(dualT4, dualT)
+    dualT4 = promote_dual(dualgen(T4), dualT)
 
     iip_arglists = (Tuple{T1, T2, T3, T4},    # primal
         Tuple{dualT1, dualT2, T3, T4},        # vjp
         Tuple{dualT1, T2, T3, dualT4},        # tgrad
-        Tuple{dualT1, T2, T3, dualT4_T},      # tgrad inside gradient wrt initial conditions
         )
 
     iip_returnlists = ntuple(x -> Nothing, length(iip_arglists))

--- a/src/norecompile.jl
+++ b/src/norecompile.jl
@@ -58,10 +58,12 @@ function wrapfun_iip(ff,
     dualT1 = ArrayInterface.promote_eltype(T1, dualT)
     dualT2 = ArrayInterface.promote_eltype(T2, dualT)
     dualT4 = dualgen(T4)
+    dualT4_T = promote_dual(dualT4, dualT)
 
-    iip_arglists = (Tuple{T1, T2, T3, T4}, # primal
-        Tuple{dualT1, dualT2, T3, T4},     # vjp
-        Tuple{dualT1, T2, T3, dualT4},     # tgrad
+    iip_arglists = (Tuple{T1, T2, T3, T4},    # primal
+        Tuple{dualT1, dualT2, T3, T4},        # vjp
+        Tuple{dualT1, T2, T3, dualT4},        # tgrad
+        Tuple{dualT1, T2, T3, dualT4_T},      # tgrad inside gradient wrt initial conditions
         )
 
     iip_returnlists = ntuple(x -> Nothing, length(iip_arglists))

--- a/src/norecompile.jl
+++ b/src/norecompile.jl
@@ -59,10 +59,10 @@ function wrapfun_iip(ff,
     dualT2 = ArrayInterface.promote_eltype(T2, dualT)
     dualT4 = dualgen(T4)
 
-    iip_arglists = (Tuple{T1, T2, T3, T4},
-        Tuple{dualT1, dualT2, T3, T4},
-        Tuple{dualT1, T2, T3, dualT4},
-        Tuple{dualT1, dualT2, T3, dualT4})
+    iip_arglists = (Tuple{T1, T2, T3, T4}, # primal
+        Tuple{dualT1, dualT2, T3, T4},     # vjp
+        Tuple{dualT1, T2, T3, dualT4},     # tgrad
+        )
 
     iip_returnlists = ntuple(x -> Nothing, 4)
 

--- a/src/norecompile.jl
+++ b/src/norecompile.jl
@@ -57,7 +57,7 @@ function wrapfun_iip(ff,
     dualT = dualgen(T)
     dualT1 = ArrayInterface.promote_eltype(T1, dualT)
     dualT2 = ArrayInterface.promote_eltype(T2, dualT)
-    dualT4 = dualgen(promote_type(T, T4))
+    dualT4 = dualgen(T4)
 
     iip_arglists = (Tuple{T1, T2, T3, T4},
         Tuple{dualT1, dualT2, T3, T4},

--- a/src/norecompile.jl
+++ b/src/norecompile.jl
@@ -64,7 +64,7 @@ function wrapfun_iip(ff,
         Tuple{dualT1, T2, T3, dualT4},     # tgrad
         )
 
-    iip_returnlists = ntuple(x -> Nothing, 4)
+    iip_returnlists = ntuple(x -> Nothing, length(iip_arglists))
 
     fwt = map(iip_arglists, iip_returnlists) do A, R
         FunctionWrappersWrappers.FunctionWrappers.FunctionWrapper{R, A}(Void(ff))


### PR DESCRIPTION
this is the second part of the fix for https://github.com/SciML/DifferentialEquations.jl/issues/994