### PR TITLE
add `_rate_prototype` function for getting the type of `du`

### DIFF
--- a/ext/DiffEqBaseUnitfulExt.jl
+++ b/ext/DiffEqBaseUnitfulExt.jl
@@ -30,4 +30,5 @@ end
     real(abs2(x) / oneunit(x) * oneunit(x))
 end
 
+_rate_prototype(u, t, onet) = u / unit(t)
 end

--- a/ext/DiffEqBaseUnitfulExt.jl
+++ b/ext/DiffEqBaseUnitfulExt.jl
@@ -30,5 +30,5 @@ end
     real(abs2(x) / oneunit(x) * oneunit(x))
 end
 
-_rate_prototype(u, t, onet) = u / unit(t)
+DiffEqBase._rate_prototype(u, t, onet) = u / unit(t)
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -62,4 +62,5 @@ function default_logger(logger)
     LoggingExtras.TeeLogger(logger1, logger2)
 end
 
-_rate_prototype(u, t::T, onet::T) where {T} = u / oneunit(t)
+# for the non-unitful case the correct type is just u
+_rate_prototype(u, t::T, onet::T) where {T} = u

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -61,3 +61,5 @@ function default_logger(logger)
 
     LoggingExtras.TeeLogger(logger1, logger2)
 end
+
+_rate_prototype(u, t::T, onet::T) where {T} = u / oneunit(t)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -3,6 +3,7 @@ using Test
 using DiffEqBase, ForwardDiff
 using DiffEqBase: prob2dtmin, timedepentdtmin, _rate_prototype
 using Unitful
+using ForwardDiff: Dual, Tag
 
 @testset "tspan2dtmin" begin
     # we only need to test very rough equality since timestepping isn't science.

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,7 +1,8 @@
 using Test
 
 using DiffEqBase, ForwardDiff
-using DiffEqBase: prob2dtmin, timedepentdtmin
+using DiffEqBase: prob2dtmin, timedepentdtmin, _rate_prototype
+using Unitful
 
 @testset "tspan2dtmin" begin
     # we only need to test very rough equality since timestepping isn't science.
@@ -31,4 +32,13 @@ end
     @test prob2dtmin((0.0, 10.0), 1.0, false) == eps(Float64)
     @test prob2dtmin((0.0f0, 10.0f0), 1.0f0, false) == eps(Float32)
     @test prob2dtmin((0.0, 10.0), ForwardDiff.Dual(1.0), false) == eps(Float64)
+end
+
+@testset "_rate_prototype" begin
+    @test _rate_prototype([1f0], 1.0, 1.0) isa Vector{Float32}
+    td = Dual{Tag{typeof(+), Float64}}(2.0,1.0)
+    @test _rate_prototype([1f0], td, td) isa Vector{Float32}
+    xd = [Dual{Tag{typeof(+), Float32}}(2.0,1.0)]
+    @test _rate_prototype(xd, 1.0, 1.0) isa typeof(xd)
+    @test _rate_prototype([u"1f0m"], u"1.0s", 1.0) isa typeof([u"1f0m/s"])
 end


### PR DESCRIPTION
from the type of `u` and `t`
This is designed to simplify handling in `OrdinaryDiffEq` which reimpliments this logic several times (and gets the `unitful` version wrong).