### PR TITLE
Change the default norm for NonlinearSolve to norm(_, 2)

### DIFF
--- a/.github/workflows/Downstream.yml
+++ b/.github/workflows/Downstream.yml
@@ -26,6 +26,7 @@ jobs:
           - {user: SciML, repo: DelayDiffEq.jl, group: Regression}
           - {user: SciML, repo: JumpProcesses.jl, group: All}
           - {user: SciML, repo: DiffEqFlux.jl, group: DiffEqFlux}
+          - {user: SciML, repo: NonlinearSolve.jl, group: All}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceI}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceII}
           - {user: SciML, repo: OrdinaryDiffEq.jl, group: InterfaceIII}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.141.1"
+version = "6.141.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
RMS-Norm causes problem with some of the algorithms, especially TR and Bad-Broyden Updates

We could use Inf Norm for size invariance but I haven't tested it out