### PR TITLE
Throw a nicer error if eltype is not a number

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -588,7 +588,7 @@ function solve_call(_prob, args...; merge_callbacks = true, kwargshandle = nothi
                 throw(NonConcreteEltypeError(RecursiveArrayTools.recursive_unitless_eltype(_prob.u0)))
             end
 
-            if !(eltype(_prob.u0) isa Number)
+            if !(eltype(_prob.u0) <: Number)
                 throw(NonNumberEltypeError(RecursiveArrayTools.recursive_unitless_eltype(_prob.u0)))
             end
         end

--- a/test/downstream/solve_error_handling.jl
+++ b/test/downstream/solve_error_handling.jl
@@ -74,3 +74,11 @@ prob = SDEProblem(f,
     noise_rate_prototype = complex(zeros(2, 4)),
     noise = StochasticDiffEq.RealWienerProcess(0.0, zeros(3)))
 @test_throws DiffEqBase.NoiseSizeIncompatabilityError solve(prob, LambaEM())
+
+function g!(du,u,p,t)
+    du[1] .= u[1] + ones(3,3)
+    du[2] .= ones(3,3)
+ end
+ u0 = [zeros(3,3),zeros(3,3)]
+ prob = ODEProblem(g!,u0,(0,1.0))
+@test_throws DiffEqBase.NonNumberEltypeError solve(prob,Tsit5())


### PR DESCRIPTION
```julia

julia>  solve(prob,Tsit5())
ERROR: Non-Number element type inside of an `Array` detected.
Arrays with non-number element types, such as
`Array{Array{Float64}}`, are not supported by the
solvers.

If you are trying to use an array of arrays structure,
look at the tools in RecursiveArrayTools.jl. For example:

If this was a mistake, promote the element types to be
all the same. If this was intentional, for example,
using Unitful.jl with different unit values, then use
an array type which has fast broadcast support for
heterogeneous values such as the ArrayPartition
from RecursiveArrayTools.jl. For example:

```julia
using RecursiveArrayTools
u0 = ArrayPartition([1.0,2.0],[3.0,4.0])
u0 = VectorOfArray([1.0,2.0],[3.0,4.0])
```

are both initial conditions which would be compatible with
the solvers.

Element type:
Matrix{Float64}

Some of the types have been truncated in the stacktrace for improved reading. To emit complete information
in the stack trace, evaluate `TruncatedStacktraces.VERBOSE[] = true` and re-run the code.

Stacktrace:
 [1] solve_call(_prob::ODEProblem{…}, args::Tsit5{…}; merge_callbacks::Bool, kwargshandle::Nothing, kwargs::@Kwargs{})
   @ DiffEqBase c:\Users\accou\.julia\dev\DiffEqBase\src\solve.jl:591
 [2] solve_call(_prob::ODEProblem{…}, args::Tsit5{…})
   @ DiffEqBase c:\Users\accou\.julia\dev\DiffEqBase\src\solve.jl:565
 [3] solve_up(prob::ODEProblem{…}, sensealg::Nothing, u0::Vector{…}, p::SciMLBase.NullParameters, args::Tsit5{…}; kwargs::@Kwargs{})
   @ DiffEqBase C:\Users\accou\.julia\packages\DiffEqBase\a6p43\src\solve.jl:1010
 [4] solve_up(prob::ODEProblem{…}, sensealg::Nothing, u0::Vector{…}, p::SciMLBase.NullParameters, args::Tsit5{…})
   @ DiffEqBase C:\Users\accou\.julia\packages\DiffEqBase\a6p43\src\solve.jl:996
 [5] solve(prob::ODEProblem{…}, args::Tsit5{…}; sensealg::Nothing, u0::Nothing, p::Nothing, wrap::Val{…}, kwargs::@Kwargs{})
   @ DiffEqBase C:\Users\accou\.julia\packages\DiffEqBase\a6p43\src\solve.jl:933
 [6] solve(prob::ODEProblem{…}, args::Tsit5{…})
   @ DiffEqBase C:\Users\accou\.julia\packages\DiffEqBase\a6p43\src\solve.jl:923
 [7] top-level scope
   @ REPL[5]:1
Some type information was truncated. Use `show(err)` to see complete types.
```