### PR TITLE
Fix TrackedArray reshaping

### DIFF
--- a/ext/DiffEqBaseReverseDiffExt.jl
+++ b/ext/DiffEqBaseReverseDiffExt.jl
@@ -21,6 +21,9 @@ end
 DiffEqBase.value(x::ReverseDiff.TrackedReal) = x.value
 DiffEqBase.value(x::ReverseDiff.TrackedArray) = x.value
 
+# Force TrackedArray from TrackedReal when reshaping W\b
+DiffEqBase._reshape(v::AbstractVector{<:ReverseDiff.TrackedReal}, siz) = reduce(vcat, v)
+
 DiffEqBase.promote_u0(u0::ReverseDiff.TrackedArray, p::ReverseDiff.TrackedArray, t0) = u0
 function DiffEqBase.promote_u0(u0::AbstractArray{<:ReverseDiff.TrackedReal},
     p::ReverseDiff.TrackedArray, t0)


### PR DESCRIPTION
Fixes https://github.com/SciML/SciMLSensitivity.jl/issues/943

```julia
using DifferentialEquations
using SciMLSensitivity.SciMLBase: RightRootFind
using SciMLSensitivity
using ForwardDiff, ReverseDiff, Zygote, FiniteDiff
using Test

GRAVITY = 9.81
MASS = 1.0
NUM_STATES = 2

t_start = 0.0
t_step = 0.05
t_stop = 2.0
tData = t_start:t_step:t_stop
u0 = [1.0, 0.0] # start state: ball position (1.0) and velocity (0.0)
p = [GRAVITY, MASS]

# setup BouncingBallODE
function fx(u, p, t)
    g, m = p
    return [u[2], -g]
end

ff = ODEFunction{false}(fx)
prob = ODEProblem{false}(ff, u0, (t_start, t_stop), p)

function loss(p)
    solution = solve(prob; p=p, alg=solver, saveat=tData, sensealg=sensealg, abstol=1e-10, reltol=1e-10)
    # fix for ReverseDiff
    if !isa(solution, ReverseDiff.TrackedArray) && !isa(solution, Array)
        sum(abs.(collect(u[1] for u in solution.u)))
    else
        sum(abs.(solution[1,:]))
    end
end

solver = Rosenbrock23(autodiff=false)
sensealg = ReverseDiffAdjoint()

loss(p)
grad_fi = FiniteDiff.finite_difference_gradient(loss, p)
grad_fd = ForwardDiff.gradient(loss, p)
grad_zg = Zygote.gradient(loss, p)[1]
grad_rd = ReverseDiff.gradient(loss, p)
@test grad_fd ≈ grad_fi atol=1e-2
@test grad_fd ≈ grad_zg
@test grad_fd ≈ grad_rd
```
