### PR TITLE
Update ForwardDiff detection for v1.10

### DIFF
--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -114,9 +114,7 @@ anyeltypedual(x::Union{ForwardDiff.AbstractConfig, Module}, counter = 0) = Any
 anyeltypedual(x::Type{T}, counter = 0) where {T <: ForwardDiff.AbstractConfig} = Any
 anyeltypedual(x::SciMLBase.RecipesBase.AbstractPlot, counter = 0) = Any
 
-if VERSION >= v"1.7"
-    anyeltypedual(x::Returns, counter = 0) = anyeltypedual(x.value, counter)
-end
+anyeltypedual(x::Returns, counter = 0) = anyeltypedual(x.value, counter)
 
 if isdefined(PreallocationTools, :FixedSizeDiffCache)
     anyeltypedual(x::PreallocationTools.FixedSizeDiffCache, counter = 0) = Any

--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -81,12 +81,11 @@ p_possibilities17 = [
     MyStruct(2.0, ForwardDiff.Dual(2.0)), [MyStruct(2.0, ForwardDiff.Dual(2.0))],
     [MyStruct(2.0, [2.0, ForwardDiff.Dual(2.0)])],
     [MyStruct(2.0, (2.0, ForwardDiff.Dual(2.0)))],
-    ((;), ForwardDiff.Dual(2.0)), MyStruct3(ForwardDiff.Dual(2.0)),
     (Mod, ForwardDiff.Dual(2.0)), (() -> 2.0, ForwardDiff.Dual(2.0)),
     (Base.pointer([2.0]), ForwardDiff.Dual(2.0)),
+    Returns((a = 2, b = 1.3, c = ForwardDiff.Dual(2.0f0))),
+    ((;), ForwardDiff.Dual(2.0)),
 ]
-VERSION >= v"1.7" &&
-    push!(p_possibilities17, Returns((a = 2, b = 1.3, c = ForwardDiff.Dual(2.0f0))))
 
 for p in p_possibilities17
     @show p
@@ -101,12 +100,12 @@ for p in p_possibilities17
           AbstractArray{<:Complex{<:ForwardDiff.Dual}}
 
     if VERSION >= v"1.7"
-        # v1.6 does not infer `getproperty` mapping
-        @inferred DiffEqBase.anyeltypedual(p)
-        ci = InteractiveUtils.@code_typed DiffEqBase.anyeltypedual(p)
-        @show filter(!=(Expr(:code_coverage_effect)), ci.first.code)
-        #@test count(x -> (x != (Expr(:code_coverage_effect))) &&
-        #                (x != GlobalRef(DiffEqBase, :Any)), ci.first.code) == 1
+    # v1.6 does not infer `getproperty` mapping
+    @inferred DiffEqBase.anyeltypedual(p)
+    ci = InteractiveUtils.@code_typed DiffEqBase.anyeltypedual(p)
+    @show filter(!=(Expr(:code_coverage_effect)), ci.first.code)
+    #@test count(x -> (x != (Expr(:code_coverage_effect))) &&
+    #                (x != GlobalRef(DiffEqBase, :Any)), ci.first.code) == 1
     end
 end
 
@@ -262,5 +261,4 @@ for p in p_possibilities_configs_not_inferred
 end
 
 # use `getfield` on `Pairs`, see https://github.com/JuliaLang/julia/pull/39448
-VERSION >= v"1.7" &&
-    @test_nowarn DiffEqBase.DualEltypeChecker(pairs((;)), 0)(Val(:data))
+@test_nowarn DiffEqBase.DualEltypeChecker(pairs((;)), 0)(Val(:data))


### PR DESCRIPTION
The test case removed looks... weird. MWE:

```
using ForwardDiff, DiffEqBase, Test
struct MyStruct3{T, T2}
    x::T
    y::T2
    MyStruct3(x) = new{typeof(x), Float64}(x)
end
p = MyStruct3(ForwardDiff.Dual(2.0))
@inferred DiffEqBase.anyeltypedual(p)
```

But Cthulhu says it's inferred:

```
julia> @descend DiffEqBase.anyeltypedual(p)
anyeltypedual(x) @ DiffEqBase C:\Users\accou\.julia\packages\DiffEqBase\3rYpM\src\forwarddiff.jl:101
[ Info: This method only fills in default arguments; descend into the body method to see the full source.
101 function anyeltypedual(x::MyStruct3{ForwardDiff.Dual{Nothing, Float64, 0}, Float64}, counter = 0)::Core.Const(ForwardDiff.Dual{Nothing, Float64, 0})
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [w]arn, [h]ide type-stable statements, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native, [j]ump to source always, [v]scode: inlay types, [V]scode: diagnostics.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
 • %1 = < constprop > anyeltypedual(::MyStruct3{ForwardDiff.Dual{Nothing, Float64, 0}, Float64},::Core.Const(0))::Core.Const(ForwardDiff.Dual{Nothing, Float64, 0})
```
