### PR TITLE
reinitialize DAEs in between calling `callback.affect!` and the second `savevalues!`

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -603,6 +603,9 @@ end
         end
         integrator.u_modified = true
         callback.affect!(integrator)
+        if integrator.sol.prob isa DAEProblem || !(integrator.f.mass_matrix isa UniformScaling)
+            DiffEqBase.initialize_dae!(integrator)
+        end
         @inbounds if callback.save_positions[2]
             savevalues!(integrator, true)
             saved_in_cb = true


### PR DESCRIPTION
…

## Checklist

- [ ] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2127