### PR TITLE
fix: edge case when SciMLFunction.mass_matrix does not exist

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -603,7 +603,8 @@ end
         end
         integrator.u_modified = true
         callback.affect!(integrator)
-        if integrator.sol.prob isa DAEProblem || !(integrator.f.mass_matrix isa UniformScaling)
+        if integrator.sol.prob isa DAEProblem || SciMLBase.__has_mass_matrix(integrator.f) &&
+            !(integrator.f.mass_matrix isa UniformScaling)
             DiffEqBase.initialize_dae!(integrator)
         end
         @inbounds if callback.save_positions[2]


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
