### PR TITLE
remove a double union splitting situation

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -978,13 +978,13 @@ function solve(prob::AbstractDEProblem, args...; sensealg = nothing,
         sensealg = prob.kwargs[:sensealg]
     end
 
-    u0 = u0 !== nothing ? u0 : prob.u0
-    p = p !== nothing ? p : prob.p
+    _u0 = u0 !== nothing ? u0 : prob.u0
+    _p = p !== nothing ? p : prob.p
 
     if wrap isa Val{true}
-        wrap_sol(solve_up(prob, sensealg, u0, p, args...; kwargs...))
+        wrap_sol(solve_up(prob, sensealg, _u0, _p, args...; kwargs...))
     else
-        solve_up(prob, sensealg, u0, p, args...; kwargs...)
+        solve_up(prob, sensealg, _u0, _p, args...; kwargs...)
     end
 end
 


### PR DESCRIPTION
This could fix a type instability I noticed while working on https://github.com/SciML/SciMLExpectations.jl/pull/148.
I don't have time to add tests for this.

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
