### PR TITLE
Add anyeltypedual methods ignoring  DiffResults.DiffResult in Dual upconversion

### DIFF
--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -122,7 +122,7 @@ function anyeltypedual(x::Type{T},
                                                               ForwardDiff.AbstractConfig}
     Any
 end
-function anyeltypedual(x::Union{ForwardDiff.DiffResults.DiffResult, Module},
+function anyeltypedual(x::ForwardDiff.DiffResults.DiffResult,
         ::Type{Val{counter}} = Val{0}) where {counter}
     Any
 end

--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -122,6 +122,15 @@ function anyeltypedual(x::Type{T},
                                                               ForwardDiff.AbstractConfig}
     Any
 end
+function anyeltypedual(x::Union{ForwardDiff.DiffResults.DiffResult, Module},
+        ::Type{Val{counter}} = Val{0}) where {counter}
+    Any
+end
+function anyeltypedual(x::Type{T},
+        ::Type{Val{counter}} = Val{0}) where {counter} where {T <:
+                                                              ForwardDiff.DiffResults.DiffResult}
+    Any
+end
 function anyeltypedual(x::SciMLBase.RecipesBase.AbstractPlot,
         ::Type{Val{counter}} = Val{0}) where {counter}
     Any


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated (_no updates necessary_)
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API (_no new documentation necessary_)
  
## Additional context

This addresses https://github.com/SciML/DiffEqBase.jl/issues/1009 by adding appropriate methods for `DiffResults.DiffResult` to `anyeltypedual()` which prevents upconversion of states to ForwardDiff.Dual numbers. Since DiffResults.DiffResult types are only used for pre-allocating outputs, this follows the spirit of the methods used for `ForwardDiff.AbstractConfig` and `PreallocationTools.FixedSizeDiffCache`.

