### PR TITLE
fix `anyeltypedual(::Union)` and a few minor cleanups

### DIFF
--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -35,7 +35,7 @@ p_possibilities = [ForwardDiff.Dual(2.0), (ForwardDiff.Dual(2.0), 2.0),
     (; x = 2.0, y = [ForwardDiff.Dual(2.0)]), (; x = 2.0, y = [[ForwardDiff.Dual(2.0)]]),
     Set([2.0, ForwardDiff.Dual(2.0)]), (SciMLBase.NullParameters(), ForwardDiff.Dual(2.0)),
     ((), ForwardDiff.Dual(2.0)), ForwardDiff.Dual{Nothing}(ForwardDiff.Dual{MyStruct}(2.0)),
-    (plot(), ForwardDiff.Dual(2.0))
+    (plot(), ForwardDiff.Dual(2.0)), [(1.0, ForwardDiff.Dual(1.0, (1.0,)))]
 ]
 
 for p in p_possibilities
@@ -293,7 +293,7 @@ p = EOS()
 @test !(DiffEqBase.anyeltypedual(p) <: ForwardDiff.Dual)
 @inferred DiffEqBase.anyeltypedual(p)
 
-# Check methods used for prevention of Dual-detection when using 
+# Check methods used for prevention of Dual-detection when using
 # DiffResults.DiffResult in a wrapper.
 # https://github.com/SciML/DiffEqBase.jl/issues/1009
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

While I was looking at this, I broadened a few `Set` and `Array` to `AbstractSet` and `AbstractArray` to better support non-base types.
