### PR TITLE
fix: fallback to empty vector when resid_prototype is nothing for NonlinearLeastSquaresProblem

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -697,7 +697,7 @@ function build_null_solution(
         prob::NonlinearLeastSquaresProblem,
         args...; abstol = 1e-6, kwargs...)
     if isinplace(prob)
-        resid = copy(prob.f.resid_prototype)
+        resid = isnothing(prob.f.resid_prototype) ? Float64[] : copy(prob.f.resid_prototype)
         prob.f(resid, prob.u0, prob.p)
     else
         resid = prob.f(prob.u0, prob.p)


### PR DESCRIPTION
Found this coming from `NonlinearSystems` where `structural_simplify` reduces the equations to 0, hence `u0` becomes nothing and `resid_prototype` becomes nothing.

MWE:

```julia
@variables u1
@parameters k=1.0 r=1.0 u2=1.0
eq = [0 ~ -u2 + (k - u1)/r]
@named n = NonlinearSystem(eq, [u1], [u2, k, r])
sys = structural_simplify(n)
np = NonlinearLeastSquaresProblem(sys, [], [u2 => 1.0, k => 1.0, r => 1.0])
sol = solve(np)
sol[u1]
```