### PR TITLE
Incorrect ordering of promotion

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.149.2"
+version = "6.149.3"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/ext/DiffEqBaseTrackerExt.jl
+++ b/ext/DiffEqBaseTrackerExt.jl
@@ -99,7 +99,7 @@ Tracker.@grad function DiffEqBase.solve_up(prob,
         kwargs...)
     out = DiffEqBase._solve_adjoint(prob, sensealg, Tracker.data(u0), Tracker.data(p),
         SciMLBase.TrackerOriginator(), args...; kwargs...)
-    Array(out[1]), out[2]
+    convert(AbstractArray, out[1]), out[2]
 end
 
 end

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1130,23 +1130,23 @@ function get_concrete_problem(prob::AbstractJumpProblem, isadapt; kwargs...)
 end
 
 function get_concrete_problem(prob::SteadyStateProblem, isadapt; kwargs...)
-    u0 = get_concrete_u0(prob, isadapt, Inf, kwargs)
-    u0 = promote_u0(u0, prob.p, nothing)
     p = get_concrete_p(prob, kwargs)
+    u0 = get_concrete_u0(prob, isadapt, Inf, kwargs)
+    u0 = promote_u0(u0, p, nothing)
     remake(prob; u0 = u0, p = p)
 end
 
 function get_concrete_problem(prob::NonlinearProblem, isadapt; kwargs...)
-    u0 = get_concrete_u0(prob, isadapt, nothing, kwargs)
-    u0 = promote_u0(u0, prob.p, nothing)
     p = get_concrete_p(prob, kwargs)
+    u0 = get_concrete_u0(prob, isadapt, nothing, kwargs)
+    u0 = promote_u0(u0, p, nothing)
     remake(prob; u0 = u0, p = p)
 end
 
 function get_concrete_problem(prob::NonlinearLeastSquaresProblem, isadapt; kwargs...)
-    u0 = get_concrete_u0(prob, isadapt, nothing, kwargs)
-    u0 = promote_u0(u0, prob.p, nothing)
     p = get_concrete_p(prob, kwargs)
+    u0 = get_concrete_u0(prob, isadapt, nothing, kwargs)
+    u0 = promote_u0(u0, p, nothing)
     remake(prob; u0 = u0, p = p)
 end
 


### PR DESCRIPTION
If `p` is not extracted before, then it tries to promote `u0` to the tracked type.