### PR TITLE
Don't check for large values in the unstable check

### DIFF
--- a/src/common_defaults.jl
+++ b/src/common_defaults.jl
@@ -104,16 +104,18 @@ function NAN_CHECK(x::SparseArrays.AbstractSparseMatrixCSC)
     any(NAN_CHECK, SparseArrays.nonzeros(x))
 end
 
-INFINITE_OR_GIANT(x::Number) = !isfinite(x)
-INFINITE_OR_GIANT(x::Union{AbstractArray, RecursiveArrayTools.AbstractVectorOfArray}) = any(
-    INFINITE_OR_GIANT, x)
-INFINITE_OR_GIANT(x::RecursiveArrayTools.ArrayPartition) = any(INFINITE_OR_GIANT, x.x)
-function INFINITE_OR_GIANT(x::SparseArrays.AbstractSparseMatrixCSC)
-    any(INFINITE_OR_GIANT, SparseArrays.nonzeros(x))
+NONFINITE_CHECK(x::Number) = !isfinite(x)
+NONFINITE_CHECK(x::Enum) = false
+NONFINITE_CHECK(x::Union{AbstractArray, RecursiveArrayTools.AbstractVectorOfArray}) = any(
+    NONFINITE_CHECK, x)
+NONFINITE_CHECK(x::RecursiveArrayTools.ArrayPartition) = any(NAN_CHECK, x.x)
+function NONFINITE_CHECK(x::SparseArrays.AbstractSparseMatrixCSC)
+    any(NONFINITE_CHECK, SparseArrays.nonzeros(x))
 end
+
 ODE_DEFAULT_UNSTABLE_CHECK(dt, u, p, t) = false
 function ODE_DEFAULT_UNSTABLE_CHECK(dt, u::Union{Number, AbstractArray{<:Number}}, p, t)
-    INFINITE_OR_GIANT(u)
+    NONFINITE_CHECK(u)
 end
 
 


### PR DESCRIPTION
Fixes regression for Float32 ODEs caused by https://github.com/SciML/DiffEqBase.jl/pull/1033. This check in general doesn't really do much, and I think we probably will switch it to just be `return false` eventually, but first we need to add something to `OrdinaryDiffEq.jl` that actually checks for divergence in a more useful way (e.g. tracking number of failed steps in a row).

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
