### PR TITLE
make `promote_u0` use `isequal` rather than `==`

### DIFF
--- a/src/forwarddiff.jl
+++ b/src/forwarddiff.jl
@@ -354,7 +354,7 @@ DiffEqBase.anyeltypedual(f::SciMLBase.AbstractSciMLFunction, ::Type{Val{counter}
 @inline function promote_u0(u0, p, t0)
     if SciMLStructures.isscimlstructure(p)
         _p = SciMLStructures.canonicalize(SciMLStructures.Tunable(), p)[1]
-        if _p != p
+        if !isequal(_p, p)
             return promote_u0(u0, _p, t0)
         end
     end
@@ -381,7 +381,7 @@ end
 @inline function promote_u0(u0::AbstractArray{<:Complex}, p, t0)
     if SciMLStructures.isscimlstructure(p)
         _p = SciMLStructures.canonicalize(SciMLStructures.Tunable(), p)[1]
-        if _p != p
+        if !isequal(_p, p)
             return promote_u0(u0, _p, t0)
         end
     end

--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -366,3 +366,4 @@ SciMLStructures.canonicalize(::SciMLStructures.Tunable, f::FakeParameterObject) 
 @test DiffEqBase.promote_u0(1.0, FakeParameterObject(ReverseDiff.track(ones(3))), 0.0) isa ReverseDiff.TrackedReal
 @test DiffEqBase.promote_u0(ones(3), FakeParameterObject(ReverseDiff.track(ones(ForwardDiff.Dual, 3))), 0.0) isa ReverseDiff.TrackedArray{<:ForwardDiff.Dual}
 @test DiffEqBase.promote_u0(1.0, FakeParameterObject(ReverseDiff.track(ones(ForwardDiff.Dual, 3))), 0.0) isa ReverseDiff.TrackedReal{<:ForwardDiff.Dual}
+@test DiffEqBase.promote_u0(1.0, [NaN], 0.0) isa Vector{Float64}

--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -366,4 +366,5 @@ SciMLStructures.canonicalize(::SciMLStructures.Tunable, f::FakeParameterObject) 
 @test DiffEqBase.promote_u0(1.0, FakeParameterObject(ReverseDiff.track(ones(3))), 0.0) isa ReverseDiff.TrackedReal
 @test DiffEqBase.promote_u0(ones(3), FakeParameterObject(ReverseDiff.track(ones(ForwardDiff.Dual, 3))), 0.0) isa ReverseDiff.TrackedArray{<:ForwardDiff.Dual}
 @test DiffEqBase.promote_u0(1.0, FakeParameterObject(ReverseDiff.track(ones(ForwardDiff.Dual, 3))), 0.0) isa ReverseDiff.TrackedReal{<:ForwardDiff.Dual}
-@test DiffEqBase.promote_u0(1.0, [NaN], 0.0) isa Vector{Float64}
+@test DiffEqBase.promote_u0(NaN, [NaN], 0.0) isa Float64
+@test DiffEqBase.promote_u0([1.0], [NaN], 0.0) isa Vector{Float64}


### PR DESCRIPTION
otherwise NaN params fail