### PR TITLE
fix: access `callback.initializealg` instead of `.initialize_alg`

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -589,7 +589,7 @@ function apply_callback!(integrator,
 
     if integrator.u_modified
         if hasmethod(reeval_internals_due_to_modification!, Tuple{typeof(integrator)}, (:callback_initializealg,))
-            reeval_internals_due_to_modification!(integrator, callback_initializealg = callback.initialize_alg)
+            reeval_internals_due_to_modification!(integrator, callback_initializealg = callback.initializealg)
         else # handle legacy dispatch without kwarg
             reeval_internals_due_to_modification!(integrator)
         end
@@ -618,7 +618,7 @@ end
         callback.affect!(integrator)
         if integrator.u_modified
             if hasmethod(reeval_internals_due_to_modification!, Tuple{typeof(integrator), Bool}, (:callback_initializealg,))
-                reeval_internals_due_to_modification!(integrator, false, callback_initializealg = callback.initialize_alg)
+                reeval_internals_due_to_modification!(integrator, false, callback_initializealg = callback.initializealg)
             else # handle legacy dispatch without kwarg
                 reeval_internals_due_to_modification!(integrator, false)
             end


### PR DESCRIPTION
https://github.com/SciML/SciMLBase.jl/actions/runs/10806083008/job/29974255072?pr=784#step:6:1734

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
