### PR TITLE
doc: u0, p keyword arg in solve()

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -935,6 +935,10 @@ explanations of the timestepping algorithms, see the
 * `wrap`: Toggles whether to wrap the solution if `prob.problem_type` has a preferred
   alternate wrapper type for the solution. Useful when speed, but not shape of solution
   is important. Defaults to `Val(true)`. `Val(false)` will cancel wrapping the solution.
+* `u0`: The initial condition, overrides the one defined in the problem struct.
+  Defaults to `nothing` (no override, use the `u0` defined in `prob`).
+* `p`: The parameters, overrides the one defined in the problem struct.
+  Defaults to `nothing` (no override, use the `p` defined in `prob`).
 
 ### Progress Monitoring
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Documentation change: add doc for the `u0` and `p` keyword arguments in the `solve` call, e.g. as used in

https://docs.sciml.ai/SciMLSensitivity/stable/manual/differential_equation_sensitivities/#Using-and-Controlling-Sensitivity-Algorithms-within-AD