### PR TITLE
Add `alias` to acceptable kwargs for Aliasing API

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -97,7 +97,9 @@ const allowedkeywords = (:dense,
     :trace_level,
     :store_trace,
     # Termination condition for solvers
-    :termination_condition)
+    :termination_condition,
+    # For AbstractAliasSpecifier
+    :alias)
 
 const KWARGWARN_MESSAGE = """
                           Unrecognized keyword arguments found.


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ x] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [ x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ x] Any new documentation only uses public API
  
## Additional context

This adds `alias` to the list of acceptable common solve kwargs. 
Also bumps the minor version since technically it's a new "feature" I think?