### PR TITLE
Add `ODE_DEFAULT_NORM` overload for GTPSA

### DIFF
--- a/ext/DiffEqBaseGTPSAExt.jl
+++ b/ext/DiffEqBaseGTPSAExt.jl
@@ -13,13 +13,21 @@ end
 value(x::TPS) = scalar(x)
 value(::Type{TPS{T}}) where {T} = T
 
-ODE_DEFAULT_NORM(u::TPS, t) = @fastmath abs(value(u))
-ODE_DEFAULT_NORM(f::F, u::TPS, t) where {F} = @fastmath abs(f(value(u)))
+ODE_DEFAULT_NORM(u::TPS, t) = normTPS(u)
+ODE_DEFAULT_NORM(f::F, u::TPS, t) where {F} = normTPS(f(u))
 
-function ODE_DEFAULT_NORM(u::AbstractArray{TPS{T}}, t) where {T <: Union{AbstractFloat, Complex}}
+function ODE_DEFAULT_NORM(u::AbstractArray{TPS{T}}, t) where {T}
     x = zero(real(T))
     @inbounds @fastmath for ui in u
-        x += abs2(value(ui))
+        x += normTPS(ui)^2
+    end
+    Base.FastMath.sqrt_fast(x / max(length(u), 1))
+end
+
+function ODE_DEFAULT_NORM(f::F, u::AbstractArray{TPS{T}}, t) where {F, T}
+    x = zero(real(T))
+    @inbounds @fastmath for ui in u
+        x += normTPS(f(ui))^2
     end
     Base.FastMath.sqrt_fast(x / max(length(u), 1))
 end

--- a/ext/DiffEqBaseGTPSAExt.jl
+++ b/ext/DiffEqBaseGTPSAExt.jl
@@ -2,16 +2,26 @@ module DiffEqBaseGTPSAExt
 
 if isdefined(Base, :get_extension)
     using DiffEqBase
-    import DiffEqBase: value
+    import DiffEqBase: value, ODE_DEFAULT_NORM
     using GTPSA
 else
     using ..DiffEqBase
-    import ..DiffEqBase: value
+    import ..DiffEqBase: value, ODE_DEFAULT_NORM
     using ..GTPSA
 end
 
-value(x::TPS) = scalar(x);
+value(x::TPS) = scalar(x)
 value(::Type{TPS{T}}) where {T} = T
 
+ODE_DEFAULT_NORM(u::TPS, t) = @fastmath abs(value(u))
+ODE_DEFAULT_NORM(f::F, u::TPS, t) where {F} = @fastmath abs(f(value(u)))
+
+function ODE_DEFAULT_NORM(u::AbstractArray{TPS{T}}, t) where {T <: Union{AbstractFloat, Complex}}
+    x = zero(real(T))
+    @inbounds @fastmath for ui in u
+        x += abs2(value(ui))
+    end
+    Base.FastMath.sqrt_fast(x / max(length(u), 1))
+end
 
 end

--- a/test/downstream/gtpsa.jl
+++ b/test/downstream/gtpsa.jl
@@ -1,5 +1,7 @@
 using OrdinaryDiffEq, ForwardDiff, GTPSA, Test
 
+# ODEProblem 1 =======================
+
 f!(du, u, p, t) = du .= p .* u
 
 # Initial variables and parameters
@@ -37,3 +39,38 @@ for i in 1:3
     @test Hi_FD ≈ GTPSA.hessian(sol_GTPSA.u[end][i], include_params=true)
 end
 
+
+# ODEProblem 2 =======================
+pdot!(dq, p, q, params, t) = dq .= [0.0, 0.0, 0.0] 
+qdot!(dp, p, q, params, t) = dp .= [p[1] / sqrt((1 + p[3])^2 - p[1]^2 - p[2]^2), 
+                                    p[2] / sqrt((1 + p[3])^2 - p[1]^2 - p[2]^2),
+                                    p[3] / sqrt(1 + p[3]^2) - (p[3] + 1)/sqrt((1 + p[3])^2 - p[1]^2 - p[2]^2)]
+
+prob = DynamicalODEProblem(pdot!, qdot!, [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], (0.0, 25.0))
+sol = solve(prob, Yoshida6(), dt = 1.0, reltol=1e-16, abstol=1e-16)
+
+desc = Descriptor(6, 2) # 6 variables to 2nd order
+dx  = vars(desc) # identity map
+prob_GTPSA = DynamicalODEProblem(pdot!, qdot!, dx[1:3], dx[4:6], (0.0, 25.0))
+sol_GTPSA = solve(prob_GTPSA, Yoshida6(), dt = 1.0, reltol=1e-16, abstol=1e-16)
+
+@test sol.u[end] ≈ scalar.(sol_GTPSA.u[end]) # scalar gets 0th order part
+
+# Compare Jacobian against ForwardDiff
+J_FD = ForwardDiff.jacobian(zeros(6)) do t
+    prob = DynamicalODEProblem(pdot!, qdot!, t[1:3], t[4:6], (0.0, 25.0))
+    sol = solve(prob, Yoshida6(), dt = 1.0, reltol=1e-16, abstol=1e-16)
+    sol.u[end]
+end
+
+@test J_FD ≈ GTPSA.jacobian(sol_GTPSA.u[end], include_params=true)
+
+# Compare Hessians against ForwardDiff
+for i in 1:6
+    Hi_FD = ForwardDiff.hessian(zeros(6)) do t
+        prob =  DynamicalODEProblem(pdot!, qdot!, t[1:3], t[4:6], (0.0, 25.0))
+        sol = solve(prob, Yoshida6(), dt = 1.0, reltol=1e-16, abstol=1e-16)
+        sol.u[end][i]
+    end
+    @test Hi_FD ≈ GTPSA.hessian(sol_GTPSA.u[end][i], include_params=true)
+end


### PR DESCRIPTION
## Checklist

- [X] Appropriate tests were added
- [X] Any code changes were done in a way that does not break public API
- [X] All documentation related to code changes were updated
- [X] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [X] Any new documentation only uses public API
  
## Additional context

I added an overload for `ODE_DEFAULT_NORM` with `TPS` types where it calculates the 2-norm of the scalar (0th order) part of the `TPS`, and is necessary because the GTPSA C library does not allow `sqrt(TPS(0))` as the derivatives are undefined. 

The calculation of the norm of the scalar part follows from what I see in the `Tracker` extension. If instead it should calculate a norm including all monomial coefficients/partial derivatives, I can quickly change that to the function `GTPSA.normTPS`.
