### PR TITLE
Import `totallength` in ForwardDiff extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.162.1"
+version = "6.162.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/ext/DiffEqBaseForwardDiffExt.jl
+++ b/ext/DiffEqBaseForwardDiffExt.jl
@@ -6,7 +6,7 @@ using DiffEqBase: Void, FunctionWrappersWrappers, OrdinaryDiffEqTag, AbstractTim
     RecursiveArrayTools, reduce_tup, _promote_tspan, has_continuous_callback
 import DiffEqBase: hasdualpromote, wrapfun_oop, wrapfun_iip, prob2dtmin,
                    promote_tspan, anyeltypedual, isdualtype, value, ODE_DEFAULT_NORM,
-                   InternalITP, nextfloat_tdir, DualEltypeChecker, sse, totallength
+                   InternalITP, nextfloat_tdir, DualEltypeChecker, sse
 
 eltypedual(x) = eltype(x) <: ForwardDiff.Dual
 isdualtype(::Type{<:ForwardDiff.Dual}) = true
@@ -501,19 +501,19 @@ unitfulvalue(x::Type{ForwardDiff.Dual{T, V, N}}) where {T, V, N} = V
 unitfulvalue(x::ForwardDiff.Dual) = unitfulvalue(ForwardDiff.unitfulvalue(x))
 
 sse(x::ForwardDiff.Dual) = sse(ForwardDiff.value(x)) + sum(sse, ForwardDiff.partials(x))
-function totallength(x::ForwardDiff.Dual)
-    totallength(ForwardDiff.value(x)) + sum(totallength, ForwardDiff.partials(x))
+function DiffEqBase.totallength(x::ForwardDiff.Dual)
+    return DiffEqBase.totallength(ForwardDiff.value(x)) + sum(DiffEqBase.totallength, ForwardDiff.partials(x))
 end
 
 @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual, ::Any) = sqrt(sse(u))
 @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual{Tag, T}},
         t::Any) where {Tag, T}
-    sqrt(DiffEqBase.__sum(sse, u; init = sse(zero(T))) / totallength(u))
+    sqrt(DiffEqBase.__sum(sse, u; init = sse(zero(T))) / DiffEqBase.totallength(u))
 end
 @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual, ::ForwardDiff.Dual) = sqrt(sse(u))
 @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual{Tag, T}},
         ::ForwardDiff.Dual) where {Tag, T}
-    sqrt(DiffEqBase.__sum(sse, u; init = sse(zero(T))) / totallength(u))
+    sqrt(DiffEqBase.__sum(sse, u; init = sse(zero(T))) / DiffEqBase.totallength(u))
 end
 
 if !hasmethod(nextfloat, Tuple{ForwardDiff.Dual})

--- a/ext/DiffEqBaseForwardDiffExt.jl
+++ b/ext/DiffEqBaseForwardDiffExt.jl
@@ -508,12 +508,12 @@ end
 @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual, ::Any) = sqrt(sse(u))
 @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual{Tag, T}},
         t::Any) where {Tag, T}
-    sqrt(__sum(sse, u; init = sse(zero(T))) / totallength(u))
+    sqrt(DiffEqBase.__sum(sse, u; init = sse(zero(T))) / totallength(u))
 end
 @inline ODE_DEFAULT_NORM(u::ForwardDiff.Dual, ::ForwardDiff.Dual) = sqrt(sse(u))
 @inline function ODE_DEFAULT_NORM(u::AbstractArray{<:ForwardDiff.Dual{Tag, T}},
         ::ForwardDiff.Dual) where {Tag, T}
-    sqrt(__sum(sse, u; init = sse(zero(T))) / totallength(u))
+    sqrt(DiffEqBase.__sum(sse, u; init = sse(zero(T))) / totallength(u))
 end
 
 if !hasmethod(nextfloat, Tuple{ForwardDiff.Dual})
@@ -527,13 +527,6 @@ if !hasmethod(nextfloat, Tuple{ForwardDiff.Dual})
 end
 
 # bisection(f, tup::Tuple{T,T}, t_forward::Bool) where {T<:ForwardDiff.Dual} = find_zero(f, tup, Roots.AlefeldPotraShi())
-
-# Static Arrays don't support the `init` keyword argument for `sum`
-@inline __sum(f::F, args...; init, kwargs...) where {F} = sum(f, args...; init, kwargs...)
-@inline function __sum(
-        f::F, a::DiffEqBase.StaticArraysCore.StaticArray...; init, kwargs...) where {F}
-    return mapreduce(f, +, a...; init, kwargs...)
-end
 
 # Differentiation of internal solver
 

--- a/ext/DiffEqBaseForwardDiffExt.jl
+++ b/ext/DiffEqBaseForwardDiffExt.jl
@@ -6,7 +6,7 @@ using DiffEqBase: Void, FunctionWrappersWrappers, OrdinaryDiffEqTag, AbstractTim
     RecursiveArrayTools, reduce_tup, _promote_tspan, has_continuous_callback
 import DiffEqBase: hasdualpromote, wrapfun_oop, wrapfun_iip, prob2dtmin,
                    promote_tspan, anyeltypedual, isdualtype, value, ODE_DEFAULT_NORM,
-                   InternalITP, nextfloat_tdir, DualEltypeChecker, sse
+                   InternalITP, nextfloat_tdir, DualEltypeChecker, sse, totallength
 
 eltypedual(x) = eltype(x) <: ForwardDiff.Dual
 isdualtype(::Type{<:ForwardDiff.Dual}) = true

--- a/ext/DiffEqBaseReverseDiffExt.jl
+++ b/ext/DiffEqBaseReverseDiffExt.jl
@@ -4,7 +4,6 @@ using DiffEqBase
 import DiffEqBase: value
 import ReverseDiff
 import DiffEqBase.ArrayInterface
-import DiffEqBase.ForwardDiff
 
 function DiffEqBase.anyeltypedual(::Type{T},
         ::Type{Val{counter}} = Val{0}) where {counter} where {

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -4,6 +4,13 @@ unitfulvalue(x) = x
 isdistribution(u0) = false
 sse(x::Number) = abs2(x)
 
+# Static Arrays don't support the `init` keyword argument for `sum`
+@inline __sum(f::F, args...; init, kwargs...) where {F} = sum(f, args...; init, kwargs...)
+@inline function __sum(
+        f::F, a::StaticArraysCore.StaticArray...; init, kwargs...) where {F}
+    return mapreduce(f, +, a...; init, kwargs...)
+end
+
 totallength(x::Number) = 1
 totallength(x::AbstractArray) = __sum(totallength, x; init = 0)
 

--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -379,3 +379,13 @@ end
       ReverseDiff.TrackedReal{<:ForwardDiff.Dual}
 @test DiffEqBase.promote_u0(NaN, [NaN], 0.0) isa Float64
 @test DiffEqBase.promote_u0([1.0], [NaN], 0.0) isa Vector{Float64}
+
+# totallength
+val = rand(10)
+par = rand(10)
+u = Dual.(val, par)
+@test DiffEqBase.totallength(val[1]) == 1
+@test DiffEqBase.totallength(val) == length(val)
+@test DiffEqBase.totallength(par) == length(par)
+@test DiffEqBase.totallength(u[1]) == DiffEqBase.totallength(val[1]) + DiffEqBase.totallength(par[1])
+@test DiffEqBase.totallength(u) == sum(DiffEqBase.totallength, u)


### PR DESCRIPTION
I think this is necessary and should fix downstream issues I just ran into:

```julia
  Got exception outside of a @test
  MethodError: no method matching totallength(::Vector{ForwardDiff.Dual{ForwardDiff.Tag{Pumas.Tag, ForwardDiff.Dual{ForwardDiff.Tag{Pumas.Tag, Float64}, Float64, 2}}, ForwardDiff.Dual{ForwardDiff.Tag{Pumas.Tag, Float64}, Float64, 2}, 1}})
  The function `totallength` exists, but no method is defined for this combination of argument types.
  
  Closest candidates are:
    totallength(::ForwardDiff.Dual)
     @ DiffEqBaseForwardDiffExt ~/.julia/packages/DiffEqBase/DnAEG/ext/DiffEqBaseForwardDiffExt.jl:504
```
