### PR TITLE
fix: use `t_nounits, D_nounits` in null_de testset

### DIFF
--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -1,7 +1,8 @@
 using ModelingToolkit, OrdinaryDiffEq, SteadyStateDiffEq, Test
+using ModelingToolkit: t_nounits as t, D_nounits as D
 using ForwardDiff
 
-@variables t x(t) y(t)
+@variables x(t) y(t)
 eqs = [0 ~ x - y
        0 ~ y - x]
 
@@ -30,7 +31,7 @@ for kwargs in [
     @test sol.t[end] == step_integ.t
 end
 
-@variables t x y
+@variables x y
 eqs = [0 ~ x - y
        0 ~ y - x]
 
@@ -58,8 +59,7 @@ sol = solve(unsatprob) # Success
 # Issue#2664
 @testset "remake type promotion with empty initial conditions" begin
     @parameters P
-    @variables t x(t)
-    D = Differential(t)
+    @variables x(t)
     # numerical ODE: x′(t) = P with x(0) = 0
     sys_num = structural_simplify(ODESystem([D(x) ~ P], t, [x], [P]; name = :sys))
     prob_num_uninit = ODEProblem(sys_num, [x => 0.0], (0.0, 1.0), [P => NaN]) # uninitialized problem


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
