### PR TITLE
Add error_control keyword

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -99,7 +99,9 @@ const allowedkeywords = (:dense,
     # Termination condition for solvers
     :termination_condition,
     # For AbstractAliasSpecifier
-    :alias)
+    :alias,
+    # Fine grained error control adaptivity
+    :error_control)
 
 const KWARGWARN_MESSAGE = """
                           Unrecognized keyword arguments found.


### PR DESCRIPTION
Add an `error_control` keyword

For https://github.com/SciML/BoundaryValueDiffEq.jl/pull/287