### PR TITLE
Use ADTypes in tests

### DIFF
--- a/test/downstream/Project.toml
+++ b/test/downstream/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 Calculus = "49dc2e85-a5d0-5ad3-a950-438e2897f1b9"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
@@ -23,4 +24,6 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
+ADTypes = "1"
 MultiScaleArrays = "1.8"
+OrdinaryDiffEq = "6.91.0"

--- a/test/downstream/default_linsolve_structure.jl
+++ b/test/downstream/default_linsolve_structure.jl
@@ -1,4 +1,4 @@
-using LinearAlgebra, OrdinaryDiffEq, Test
+using LinearAlgebra, OrdinaryDiffEq, Test, ADTypes
 f = (du, u, p, t) -> du .= u ./ t
 jac = (J, u, p, t) -> (J[1, 1] = 1 / t; J[2, 2] = 1 / t; J[1, 2] = 0; J[2, 1] = 0)
 
@@ -9,7 +9,7 @@ sol = solve(prob, Rosenbrock23())
 @test sol.u[end] ≈ [10.0, 10.0]
 @test length(sol) < 60
 
-sol = solve(prob, Rosenbrock23(autodiff = false))
+sol = solve(prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
 @test sol.u[end] ≈ [10.0, 10.0]
 @test length(sol) < 60
 
@@ -21,7 +21,7 @@ sol = solve(prob, Rosenbrock23())
 @test sol.u[end] ≈ [10.0, 10.0]
 @test length(sol) < 60
 
-sol = solve(prob, Rosenbrock23(autodiff = false))
+sol = solve(prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
 @test sol.u[end] ≈ [10.0, 10.0]
 @test length(sol) < 60
 
@@ -42,7 +42,7 @@ sol = solve(prob,Rosenbrock23())
     jp = Hermitian(jp_diag)
     fun = ODEFunction(f; jac = jac, jac_prototype = jp)
     prob = ODEProblem(fun, ones(2), (1.0, 10.0))
-    sol = solve(prob, Rosenbrock23(autodiff = false))
+    sol = solve(prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
     @test sol.u[end] ≈ [10.0, 10.0]
     @test length(sol) < 60
 end
@@ -51,7 +51,7 @@ end
     jp = Symmetric(jp_diag)
     fun = ODEFunction(f; jac = jac, jac_prototype = jp)
     prob = ODEProblem(fun, ones(2), (1.0, 10.0))
-    sol = solve(prob, Rosenbrock23(autodiff = false))
+    sol = solve(prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
     @test sol.u[end] ≈ [10.0, 10.0]
     @test length(sol) < 60
 end

--- a/test/downstream/labelledarrays.jl
+++ b/test/downstream/labelledarrays.jl
@@ -1,5 +1,6 @@
 using OrdinaryDiffEq
 using LabelledArrays
+using ADTypes
 
 function f(out, du, u, p, t)
     out.x = -0.04u.x + 1e4 * u.y * u.z - du.x
@@ -25,4 +26,4 @@ u_0 = @LArray fill(1000.0, 2 * n) (x = (1:n), y = ((n + 1):(2 * n)))
 p = [0.1, 0.1]
 prob1 = ODEProblem(f1, u_0, (0, 100.0), p)
 sol = solve(prob1, Rodas5());
-sol = solve(prob1, Rodas5(autodiff = false));
+sol = solve(prob1, Rodas5(autodiff = AutoFiniteDiff()));

--- a/test/gpu/Project.toml
+++ b/test/gpu/Project.toml
@@ -1,3 +1,8 @@
 [deps]
+ADTypes = "47edcb42-4c32-4615-8424-f2b9edc5f35b"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
+
+[compat]
+ADTypes = "1"
+OrdinaryDiffEq = "6.91.0"

--- a/test/gpu/simple_gpu.jl
+++ b/test/gpu/simple_gpu.jl
@@ -1,4 +1,4 @@
-using OrdinaryDiffEq, CUDA, LinearAlgebra, Test, StaticArrays
+using OrdinaryDiffEq, CUDA, LinearAlgebra, Test, StaticArrays, ADTypes
 function f(u, p, t)
     A * u
 end
@@ -26,31 +26,33 @@ tspan = (0.0f0, 100.0f0)
 prob = ODEProblem(ff, u0, tspan)
 sol = solve(prob, Tsit5())
 @test solve(prob, Rosenbrock23()).retcode == ReturnCode.Success
-solve(prob, Rosenbrock23(autodiff = false));
+solve(prob, Rosenbrock23(autodiff = AutoFiniteDiff()));
 
 prob_oop = ODEProblem{false}(ff, u0, tspan)
 CUDA.allowscalar(false)
 sol = solve(prob_oop, Tsit5())
 @test solve(prob_oop, Rosenbrock23()).retcode == ReturnCode.Success
-@test solve(prob_oop, Rosenbrock23(autodiff = false)).retcode == ReturnCode.Success
+@test solve(prob_oop, Rosenbrock23(autodiff = AutoFiniteDiff())).retcode ==
+      ReturnCode.Success
 
 prob_nojac = ODEProblem(f, u0, tspan)
 @test solve(prob_nojac, Rosenbrock23()).retcode == ReturnCode.Success
-@test solve(prob_nojac, Rosenbrock23(autodiff = false)).retcode == ReturnCode.Success
-@test solve(prob_nojac,
-    Rosenbrock23(autodiff = false, diff_type = Val{:central})).retcode ==
+@test solve(prob_nojac, Rosenbrock23(autodiff = AutoFiniteDiff())).retcode ==
       ReturnCode.Success
 @test solve(prob_nojac,
-    Rosenbrock23(autodiff = false, diff_type = Val{:complex})).retcode ==
+    Rosenbrock23(autodiff = AutoFiniteDiff(; fdtype = Val(:central)))).retcode ==
+      ReturnCode.Success
+@test solve(prob_nojac,
+    Rosenbrock23(autodiff = AutoFiniteDiff(; fdtype = Val(:complex)))).retcode ==
       ReturnCode.Success
 
 #=
 prob_nojac_oop = ODEProblem{false}(f,u0,tspan)
 DiffEqBase.prob2dtmin(prob_nojac_oop)
 @test_broken solve(prob_nojac_oop,Rosenbrock23()).retcode == ReturnCode.Success
-@test_broken solve(prob_nojac_oop,Rosenbrock23(autodiff=false)).retcode == ReturnCode.Success
-@test_broken solve(prob_nojac_oop,Rosenbrock23(autodiff=false,diff_type = Val{:central})).retcode == ReturnCode.Success
-@test_broken solve(prob_nojac_oop,Rosenbrock23(autodiff=false,diff_type = Val{:complex})).retcode == ReturnCode.Success
+@test_broken solve(prob_nojac_oop,Rosenbrock23(autodiff=AutoFiniteDiff())).retcode == ReturnCode.Success
+@test_broken solve(prob_nojac_oop,Rosenbrock23(autodiff=AutoFiniteDiff(; fdtype = Val(:central))).retcode == ReturnCode.Success
+@test_broken solve(prob_nojac_oop,Rosenbrock23(autodiff=AutoFiniteDiff(; fdtype = Val(:complex))).retcode == ReturnCode.Success
 =#
 
 # Complex Numbers Adaptivity DifferentialEquations.jl#460


### PR DESCRIPTION
I noticed test failures in https://github.com/SciML/OrdinaryDiffEq.jl/pull/2617 due to incorrectly specified `diff_type` in the GPU tests - `Val{:central}` should be `Val(:central)` etc. This also showed up in recent buildkite runs on the DiffEqBase master branch: https://buildkite.com/julialang/diffeqbase-dot-jl/builds/1952#019513f2-5ba8-4380-bcb7-b047e9198da3/324-1050

Instead of fixing the `diff_type`s, I assumed it would be more future-proof to switch the tests to ADTypes (and hence only specify `autodiff`).