### PR TITLE
fix: pass `retcode` as kwarg

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -716,7 +716,7 @@ function build_null_solution(prob::AbstractDEProblem, args...;
 
     prob, success = hack_null_solution_init(prob)
     retcode = success ? ReturnCode.Success : ReturnCode.InitialFailure
-    build_solution(prob, nothing, ts, timeseries, retcode)
+    build_solution(prob, nothing, ts, timeseries; retcode)
 end
 
 function build_null_solution(
@@ -731,8 +731,7 @@ function build_null_solution(
         kwargs...)
     prob, success = hack_null_solution_init(prob)
     retcode = success ? ReturnCode.Success : ReturnCode.InitialFailure
-    SciMLBase.build_solution(prob, nothing, Float64[], nothing;
-        retcode)
+    SciMLBase.build_solution(prob, nothing, Float64[], nothing; retcode)
 end
 
 function build_null_solution(
@@ -752,8 +751,7 @@ function build_null_solution(
         retcode = norm(resid) < abstol ? ReturnCode.Success : ReturnCode.Failure
     end
 
-    SciMLBase.build_solution(prob, nothing, Float64[], resid;
-        retcode)
+    SciMLBase.build_solution(prob, nothing, Float64[], resid; retcode)
 end
 
 """


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
