### PR TITLE
Fix downstream AD tests

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -432,7 +432,7 @@ function find_callback_time(integrator, callback::ContinuousCallback, counter)
                     end
                     Θ = bisection(zero_func, (bottom_t, top_t), isone(integrator.tdir),
                         callback.rootfind, callback.abstol, callback.reltol)
-                    integrator.last_event_error = ODE_DEFAULT_NORM(zero_func(Θ), Θ)
+                    integrator.last_event_error = DiffEqBase.value(ODE_DEFAULT_NORM(zero_func(Θ), Θ))
                 end
                 #Θ = prevfloat(...)
                 # prevfloat guerentees that the new time is either 1 floating point
@@ -507,9 +507,7 @@ function find_callback_time(integrator, callback::VectorContinuousCallback, coun
                                 isone(integrator.tdir), callback.rootfind,
                                 callback.abstol, callback.reltol)
                             if integrator.tdir * Θ < integrator.tdir * min_t
-                                integrator.last_event_error = ODE_DEFAULT_NORM(
-                                    zero_func(Θ),
-                                    Θ)
+                                integrator.last_event_error = DiffEqBase.value(ODE_DEFAULT_NORM(zero_func(Θ), Θ))
                             end
                         end
                         if integrator.tdir * Θ < integrator.tdir * min_t


### PR DESCRIPTION
This is because the norm on (u=tracked, t=tracked) returns a tracked value, which is required for differentiating appropriately w.r.t. callback time. However, this value is just being saved for non-differentiable logic in order to know whether to include the first interval or not in the search process, and so it should be dropped.
