### PR TITLE
Tighten the interval returned by InternalITP when there's an exact zero crossing

### DIFF
--- a/src/internal_itp.jl
+++ b/src/internal_itp.jl
@@ -41,7 +41,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem{IP, Tuple{T, T}}, alg::I
             retcode = ReturnCode.ExactSolutionRight, left, right)
     end
     span = abs(right - left)
-    k1 = T(alg.scaled_k1)/span
+    k1 = T(alg.scaled_k1) / span
     n0 = T(alg.n0)
     n_h = exponent(span / (2 * ϵ))
     ϵ_s = ϵ * exp2(n_h + n0)
@@ -61,11 +61,6 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem{IP, Tuple{T, T}}, alg::I
         xt = ifelse(δ ≤ abs(diff), x_f + copysign(δ, diff), mid)  # Truncation Step
 
         xp = ifelse(abs(xt - mid) ≤ r, xt, mid - copysign(r, diff))  # Projection Step
-        if span < 2ϵ
-            return SciMLBase.build_solution(
-                prob, alg, xt, f(xt); retcode = ReturnCode.Success, left, right
-            )
-        end
         yp = f(xp)
         yps = yp * sign(fr)
         if yps > T0

--- a/src/internal_itp.jl
+++ b/src/internal_itp.jl
@@ -74,7 +74,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem{IP, Tuple{T, T}}, alg::I
             left, fl = xp, yp
         else
             return SciMLBase.build_solution(
-                prob, alg, xp, yps; retcode = ReturnCode.Success, left=xp, right=xp
+                prob, alg, xp, yps; retcode = ReturnCode.Success, left = xp, right = xp
             )
         end
 

--- a/src/internal_itp.jl
+++ b/src/internal_itp.jl
@@ -74,7 +74,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem{IP, Tuple{T, T}}, alg::I
             left, fl = xp, yp
         else
             return SciMLBase.build_solution(
-                prob, alg, xp, yps; retcode = ReturnCode.Success, left, right
+                prob, alg, xp, yps; retcode = ReturnCode.Success, left=xp, right=xp
             )
         end
 


### PR DESCRIPTION
Background is here: https://github.com/SciML/DiffEqBase.jl/pull/1127/files#r2022436123

To summarize: inside the branch where the callback condition is evaluated to an exact zero, this PR fills the `left` and `right` fields of the solution with the location of the zero crossing instead of the values at the start of that ITP iteration.