### PR TITLE
chore: pass `sensealg` to `solve_call` kwargs

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1123,7 +1123,7 @@ function solve_up(prob::Union{AbstractDEProblem, NonlinearProblem}, sensealg, u0
     if isnothing(alg) || !(alg isa AbstractDEAlgorithm) # Default algorithm handling
         _prob = get_concrete_problem(prob, !(prob isa DiscreteProblem); u0 = u0,
             p = p, kwargs...)
-        solve_call(_prob, args...; kwargs...)
+        solve_call(_prob, args...; sensealg, kwargs...)
     else
         tstops = get(kwargs, :tstops, nothing)
         if tstops === nothing && has_kwargs(prob)
@@ -1137,9 +1137,9 @@ function solve_up(prob::Union{AbstractDEProblem, NonlinearProblem}, sensealg, u0
         _alg = prepare_alg(alg, _prob.u0, _prob.p, _prob)
         check_prob_alg_pairing(_prob, alg) # use alg for improved inference
         if length(args) > 1
-            solve_call(_prob, _alg, Base.tail(args)...; kwargs...)
+            solve_call(_prob, _alg, Base.tail(args)...; sensealg, kwargs...)
         else
-            solve_call(_prob, _alg; kwargs...)
+            solve_call(_prob, _alg; sensealg, kwargs...)
         end
     end
 end


### PR DESCRIPTION
Seems passing `sensealg` to `solve_call` kwargs got missed

## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
