### PR TITLE
fix: fix method ambiguity in `promote_u0` in MonteCarloExt

### DIFF
--- a/ext/DiffEqBaseMonteCarloMeasurementsExt.jl
+++ b/ext/DiffEqBaseMonteCarloMeasurementsExt.jl
@@ -24,6 +24,12 @@ function DiffEqBase.promote_u0(u0,
     eltype(p).(u0)
 end
 
+function DiffEqBase.promote_u0(::Nothing,
+        p::AbstractArray{<:MonteCarloMeasurements.AbstractParticles},
+        t0)
+    return nothing
+end
+
 DiffEqBase.value(x::Type{MonteCarloMeasurements.AbstractParticles{T, N}}) where {T, N} = T
 DiffEqBase.value(x::MonteCarloMeasurements.AbstractParticles) = mean(x.particles)
 function DiffEqBase.unitfulvalue(x::Type{MonteCarloMeasurements.AbstractParticles{


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
