### PR TITLE
Mark null ODE solutions as dense

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.173.0"
+version = "6.173.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -748,7 +748,7 @@ function build_null_solution(prob::AbstractDEProblem, args...;
 
     prob, success = hack_null_solution_init(prob)
     retcode = success ? ReturnCode.Success : ReturnCode.InitialFailure
-    build_solution(prob, nothing, ts, timeseries; retcode)
+    build_solution(prob, nothing, ts, timeseries; dense=true, retcode)
 end
 
 function build_null_solution(

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -13,6 +13,7 @@ sys = structural_simplify(sys)
 prob = ODEProblem(sys, Pair[], (0, 10.0))
 sol = solve(prob, Tsit5())
 
+@test sol.dense
 @test sol[x] == [0.0, 0.0]
 @test sol[y] == [0.0, 0.0]
 


### PR DESCRIPTION
We actually know the entire time series for the solution, so we should state that we know that via `dense=true`.

```julia
using OrdinaryDiffEqDefault, ModelingToolkit
using ModelingToolkit: t_nounits as t, D_nounits as D

@variables x(t) y(t)
eqs = [y ~ x, y ~ sin(t)]
@mtkbuild sys = ODESystem(eqs, t)

tspan = (0.0, 10.0)
prob = ODEProblem(sys, [], tspan)
sol = solve(prob)
using Plots
plot(sol, idxs = [x])
savefig("plot.png")
```

Before and after
