### PR TITLE
Ensure internal ITP bounds are in proper order

### DIFF
--- a/src/internal_itp.jl
+++ b/src/internal_itp.jl
@@ -30,7 +30,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem{IP, Tuple{T, T}}, alg::I
         args...;
         maxiters = 1000, kwargs...) where {IP, T}
     f = Base.Fix2(prob.f, prob.p)
-    left, right = prob.tspan # a and b
+    left, right = minmax(prob.tspan...) # a and b
     fl, fr = f(left), f(right)
     ϵ = eps(T)
     if iszero(fl)
@@ -40,7 +40,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem{IP, Tuple{T, T}}, alg::I
         return SciMLBase.build_solution(prob, alg, right, fr;
             retcode = ReturnCode.ExactSolutionRight, left, right)
     end
-    span = abs(right - left)
+    span = right - left
     k1 = T(alg.scaled_k1) / span
     n0 = T(alg.n0)
     n_h = exponent(span / (2 * ϵ))
@@ -49,7 +49,7 @@ function SciMLBase.solve(prob::IntervalNonlinearProblem{IP, Tuple{T, T}}, alg::I
 
     i = 1
     while i ≤ maxiters
-        span = abs(right - left)
+        span = right - left
         mid = (left + right) / 2
         r = ϵ_s - (span / 2)
 


### PR DESCRIPTION
This is a fix for https://github.com/SciML/DifferentialEquations.jl/issues/1087.

## Checklist

- [ ] Appropriate tests were added: **This can be tested with the Minimal Reproducible Example in the original issue, but the test can't be implemented in DiffEqBase since it needs to actually solve the ODE**
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated: **Nothing to do**
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API: **Nothing to do**
  
## Additional context

We just ensure that `left < right` even if `prob.tspan` bounds are inverted when integrating backward. I got the change from the [original ITP implementation in NonlinearSolve.jl](https://github.com/SciML/NonlinearSolve.jl/blob/master/lib/BracketingNonlinearSolve/src/itp.jl)
