### PR TITLE
Respect Julia's color settings in error messages

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -131,7 +131,11 @@ function Base.showerror(io::IO, e::CommonKwargError)
     notin = collect(map(x -> x ∉ allowedkeywords, keys(e.kwargs)))
     unrecognized = collect(keys(e.kwargs))[notin]
     print(io, "Unrecognized keyword arguments: ")
-    printstyled(io, unrecognized; bold = true, color = :red)
+    if get(io, :color, false)
+        printstyled(io, unrecognized; bold = true, color = :red)
+    else
+        print(io, unrecognized)
+    end
     print(io, "\n\n")
     println(io, TruncatedStacktraces.VERBOSE_MSG)
 end
@@ -1261,7 +1265,11 @@ function checkkwargs(kwargshandle; kwargs...)
             @warn KWARGWARN_MESSAGE
             unrecognized = setdiff(keys(kwargs), allowedkeywords)
             print("Unrecognized keyword arguments: ")
-            printstyled(unrecognized; bold = true, color = :red)
+            if get(stdout, :color, false)
+                printstyled(unrecognized; bold = true, color = :red)
+            else
+                print(unrecognized)
+            end
             print("\n\n")
         else
             @assert kwargshandle == KeywordArgSilent


### PR DESCRIPTION
## Summary
- Fixed issue where error messages would display with ANSI color codes even when Julia was run with `--color=no`
- Now checks the IOContext's `:color` property before using `printstyled` with colors
- Falls back to plain `print()` when colors are disabled

## Test plan
- [ ] Run Julia with `--color=no` and verify error messages display without color codes
- [ ] Run Julia normally and verify colored error messages still work
- [ ] All existing tests pass

This change ensures that DiffEqBase respects Julia's color settings, making it compatible with environments that don't support ANSI colors (like Weave.jl).

Fixes #194

🤖 Generated with [Claude Code](https://claude.ai/code)