### PR TITLE
Add interface_checks to allowed keywords

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -101,7 +101,9 @@ const allowedkeywords = (:dense,
     # For AbstractAliasSpecifier
     :alias,
     # Parameter estimation with BVP
-    :fit_parameters)
+    :fit_parameters,
+    # Interface checks control
+    :interface_checks)
 
 const KWARGWARN_MESSAGE = """
                           Unrecognized keyword arguments found.


### PR DESCRIPTION
## Summary
- Added `interface_checks` to the list of allowed keyword arguments in `solve`
- This keyword was already documented in SciMLBase.jl PR #561 but was missing from DiffEqBase's allowed keywords list

## Test plan
- [ ] Verified that using `interface_checks = false` no longer throws an unrecognized keyword error
- [ ] All existing tests pass

## Example
Previously this would error:
```julia
using OrdinaryDiffEq
ode = ODEProblem((u, p, t) -> u, 1.0, (0.0, 1.0))
solve(ode; interface_checks = false)  # ERROR: Unrecognized keyword arguments
```

Now it's properly recognized as a valid keyword.

Fixes #980

🤖 Generated with [Claude Code](https://claude.ai/code)