### PR TITLE
Remove Julia v1.9 get_extension compatibility code

### DIFF
--- a/ext/DiffEqBaseGTPSAExt.jl
+++ b/ext/DiffEqBaseGTPSAExt.jl
@@ -1,6 +1,5 @@
 module DiffEqBaseGTPSAExt
 
-if isdefined(Base, :get_extension)
     using DiffEqBase
     import DiffEqBase: value, ODE_DEFAULT_NORM
     using GTPSA

--- a/ext/DiffEqBaseGTPSAExt.jl
+++ b/ext/DiffEqBaseGTPSAExt.jl
@@ -1,13 +1,8 @@
 module DiffEqBaseGTPSAExt
 
-    using DiffEqBase
-    import DiffEqBase: value, ODE_DEFAULT_NORM
-    using GTPSA
-else
-    using ..DiffEqBase
-    import ..DiffEqBase: value, ODE_DEFAULT_NORM
-    using ..GTPSA
-end
+using DiffEqBase
+import DiffEqBase: value, ODE_DEFAULT_NORM
+using GTPSA
 
 value(x::TPS) = scalar(x)
 value(::Type{<:TPS{T}}) where {T} = T

--- a/ext/DiffEqBaseGeneralizedGeneratedExt.jl
+++ b/ext/DiffEqBaseGeneralizedGeneratedExt.jl
@@ -1,6 +1,5 @@
 module DiffEqBaseGeneralizedGeneratedExt
 
-if isdefined(Base, :get_extension)
     using DiffEqBase
     using GeneralizedGenerated
 else

--- a/ext/DiffEqBaseGeneralizedGeneratedExt.jl
+++ b/ext/DiffEqBaseGeneralizedGeneratedExt.jl
@@ -1,11 +1,7 @@
 module DiffEqBaseGeneralizedGeneratedExt
 
-    using DiffEqBase
-    using GeneralizedGenerated
-else
-    using ..DiffEqBase
-    using ..GeneralizedGenerated
-end
+using DiffEqBase
+using GeneralizedGenerated
 
 function SciMLBase.numargs(::GeneralizedGenerated.RuntimeFn{Args}) where {Args}
     GeneralizedGenerated.from_type(Args) |> length

--- a/ext/DiffEqBaseMPIExt.jl
+++ b/ext/DiffEqBaseMPIExt.jl
@@ -1,6 +1,5 @@
 module DiffEqBaseMPIExt
 
-if isdefined(Base, :get_extension)
     using DiffEqBase
     import MPI
 else

--- a/ext/DiffEqBaseMPIExt.jl
+++ b/ext/DiffEqBaseMPIExt.jl
@@ -1,11 +1,7 @@
 module DiffEqBaseMPIExt
 
-    using DiffEqBase
-    import MPI
-else
-    using ..DiffEqBase
-    import ..MPI
-end
+using DiffEqBase
+import MPI
 
 if isdefined(MPI, :AbstractMultiRequest)
     function DiffEqBase.anyeltypedual(::Type{T},

--- a/ext/DiffEqBaseMeasurementsExt.jl
+++ b/ext/DiffEqBaseMeasurementsExt.jl
@@ -1,13 +1,8 @@
 module DiffEqBaseMeasurementsExt
 
-    using DiffEqBase
-    import DiffEqBase: value
-    using Measurements
-else
-    using ..DiffEqBase
-    import ..DiffEqBase: value
-    using ..Measurements
-end
+using DiffEqBase
+import DiffEqBase: value
+using Measurements
 
 function DiffEqBase.promote_u0(u0::AbstractArray{<:Measurements.Measurement},
         p::AbstractArray{<:Measurements.Measurement}, t0)

--- a/ext/DiffEqBaseMeasurementsExt.jl
+++ b/ext/DiffEqBaseMeasurementsExt.jl
@@ -1,6 +1,5 @@
 module DiffEqBaseMeasurementsExt
 
-if isdefined(Base, :get_extension)
     using DiffEqBase
     import DiffEqBase: value
     using Measurements

--- a/ext/DiffEqBaseMonteCarloMeasurementsExt.jl
+++ b/ext/DiffEqBaseMonteCarloMeasurementsExt.jl
@@ -1,6 +1,5 @@
 module DiffEqBaseMonteCarloMeasurementsExt
 
-if isdefined(Base, :get_extension)
     using DiffEqBase
     import DiffEqBase: value
     using MonteCarloMeasurements

--- a/ext/DiffEqBaseMonteCarloMeasurementsExt.jl
+++ b/ext/DiffEqBaseMonteCarloMeasurementsExt.jl
@@ -1,13 +1,8 @@
 module DiffEqBaseMonteCarloMeasurementsExt
 
-    using DiffEqBase
-    import DiffEqBase: value
-    using MonteCarloMeasurements
-else
-    using ..DiffEqBase
-    import ..DiffEqBase: value
-    using ..MonteCarloMeasurements
-end
+using DiffEqBase
+import DiffEqBase: value
+using MonteCarloMeasurements
 
 function DiffEqBase.promote_u0(
         u0::AbstractArray{

--- a/ext/DiffEqBaseTrackerExt.jl
+++ b/ext/DiffEqBaseTrackerExt.jl
@@ -1,6 +1,5 @@
 module DiffEqBaseTrackerExt
 
-if isdefined(Base, :get_extension)
     using DiffEqBase
     import DiffEqBase: value
     import Tracker

--- a/ext/DiffEqBaseTrackerExt.jl
+++ b/ext/DiffEqBaseTrackerExt.jl
@@ -1,13 +1,8 @@
 module DiffEqBaseTrackerExt
 
-    using DiffEqBase
-    import DiffEqBase: value
-    import Tracker
-else
-    using ..DiffEqBase
-    import ..DiffEqBase: value
-    import ..Tracker
-end
+using DiffEqBase
+import DiffEqBase: value
+import Tracker
 
 DiffEqBase.value(x::Type{Tracker.TrackedReal{T}}) where {T} = T
 DiffEqBase.value(x::Type{Tracker.TrackedArray{T, N, A}}) where {T, N, A} = Array{T, N}

--- a/ext/DiffEqBaseUnitfulExt.jl
+++ b/ext/DiffEqBaseUnitfulExt.jl
@@ -1,13 +1,9 @@
 module DiffEqBaseUnitfulExt
 
-    using DiffEqBase
-    import DiffEqBase: value
-    using Unitful
-else
-    using ..DiffEqBase
-    import ..DiffEqBase: value
-    using ..Unitful
-end
+using DiffEqBase
+import DiffEqBase: value
+using Unitful
+
 # Support adaptive errors should be errorless for exponentiation
 value(x::Type{Unitful.AbstractQuantity{T, D, U}}) where {T, D, U} = T
 value(x::Unitful.AbstractQuantity) = x.val

--- a/ext/DiffEqBaseUnitfulExt.jl
+++ b/ext/DiffEqBaseUnitfulExt.jl
@@ -1,6 +1,5 @@
 module DiffEqBaseUnitfulExt
 
-if isdefined(Base, :get_extension)
     using DiffEqBase
     import DiffEqBase: value
     using Unitful


### PR DESCRIPTION
## Description

This PR removes the compatibility checks for `isdefined(Base, :get_extension)` since all SciML packages now require Julia v1.10+, where package extensions are built-in.

## Changes

- Removed unnecessary version checks in extension loading code
- Simplified extension imports by removing conditional logic
- Cleaned up obsolete compatibility code

## Context

As identified in the SciML-wide analysis, all SciML packages have moved to requiring Julia v1.10+ as the minimum version. This makes the compatibility code for checking whether package extensions are available redundant.

The `isdefined(Base, :get_extension)` checks were used to support Julia v1.9 where extensions were loaded differently. Since we no longer support v1.9, this code can be safely removed.

## Testing

- [ ] Package tests pass locally
- [ ] No changes to functionality, only removal of version checks