### PR TITLE
Remove outdated Julia version check for v1.7

### DIFF
--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -99,14 +99,12 @@ for p in p_possibilities17
     @test DiffEqBase.promote_u0([cis(u0)], p, t0) isa
           AbstractArray{<:Complex{<:ForwardDiff.Dual}}
 
-    if VERSION >= v"1.7"
-        # v1.6 does not infer `getproperty` mapping
-        @inferred DiffEqBase.anyeltypedual(p)
-        ci = InteractiveUtils.@code_typed DiffEqBase.anyeltypedual(p)
-        @show filter(!=(Expr(:code_coverage_effect)), ci.first.code)
-        #@test count(x -> (x != (Expr(:code_coverage_effect))) &&
-        #                (x != GlobalRef(DiffEqBase, :Any)), ci.first.code) == 1
-    end
+    # v1.6 does not infer `getproperty` mapping
+    @inferred DiffEqBase.anyeltypedual(p)
+    ci = InteractiveUtils.@code_typed DiffEqBase.anyeltypedual(p)
+    @show filter(!=(Expr(:code_coverage_effect)), ci.first.code)
+    #@test count(x -> (x != (Expr(:code_coverage_effect))) &&
+    #                (x != GlobalRef(DiffEqBase, :Any)), ci.first.code) == 1
 end
 
 p_possibilities_uninferrred = [

--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -99,7 +99,6 @@ for p in p_possibilities17
     @test DiffEqBase.promote_u0([cis(u0)], p, t0) isa
           AbstractArray{<:Complex{<:ForwardDiff.Dual}}
 
-    # v1.6 does not infer `getproperty` mapping
     @inferred DiffEqBase.anyeltypedual(p)
     ci = InteractiveUtils.@code_typed DiffEqBase.anyeltypedual(p)
     @show filter(!=(Expr(:code_coverage_effect)), ci.first.code)


### PR DESCRIPTION
## Summary
- Removed conditional version check for Julia >= v1.7 in test/forwarddiff_dual_detection.jl
- Since Julia v1.10 is the current LTS, this check is no longer needed

## Changes
The version check was wrapping inference tests that can now run on all supported Julia versions. The conditional block has been removed and the tests now run unconditionally.

## Test plan
- [ ] Existing tests should continue to pass
- [ ] No functionality changes, only removal of version gating

🤖 Generated with [Claude Code](https://claude.ai/code)