### PR TITLE
Initialize line split fixes following Catalyst.jl PR #1306

### DIFF
--- a/test/downstream/community_callback_tests.jl
+++ b/test/downstream/community_callback_tests.jl
@@ -155,12 +155,8 @@ function affect!(integrator, idx)
                 x₂ = u.nodes[l][1:2]
                 v₂ = u.nodes[l][3:4]
                 # https://stackoverflow.com/a/35212639
-                v₁ = (v₁ -
-                      2 / (1 + 1) *
-                      (dot(v₁ - v₂, x₁ - x₂) / sum(abs2, x₁ - x₂) * (x₁ - x₂)))
-                v₂ = -(v₂ -
-                       2 / (1 + 1) *
-                       (dot(v₂ - v₁, x₂ - x₁) / sum(abs2, x₂ - x₁) * (x₂ - x₁)))
+                v₁ = (v₁ - 2 / (1 + 1) * (dot(v₁ - v₂, x₁ - x₂) / sum(abs2, x₁ - x₂) * (x₁ - x₂)))
+                v₂ = -(v₂ - 2 / (1 + 1) * (dot(v₂ - v₁, x₂ - x₁) / sum(abs2, x₂ - x₁) * (x₂ - x₁)))
 
                 println("Collision handled.")
 


### PR DESCRIPTION
## Summary

Initialize fixing unnecessary line splits in Julia code following the guidelines established in [Catalyst.jl PR #1306](https://github.com/SciML/Catalyst.jl/pull/1306). This PR sets up the framework for improving code readability by consolidating short expressions that are unnecessarily split across multiple lines.

## Background

These formatting issues are being addressed upstream in [JuliaFormatter.jl PR #934](https://github.com/domluna/JuliaFormatter.jl/pull/934). Since that PR is not yet merged, manual fixes are needed in the meantime to improve code readability.

## Note

This is part of a systematic effort to apply the same formatting improvements across 10+ SciML repositories following the successful implementation in JumpProcesses.jl, OrdinaryDiffEq.jl, LinearSolve.jl, and others.

🤖 Generated with [Claude Code](https://claude.ai/code)