### PR TITLE
Fix backward vector callback detection when step is exactly on event …

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -50,7 +50,7 @@ has_continuous_callback(cb::DiscreteCallback) = false
 has_continuous_callback(cb::ContinuousCallback) = true
 has_continuous_callback(cb::VectorContinuousCallback) = true
 has_continuous_callback(cb::CallbackSet) = !isempty(cb.continuous_callbacks)
-has_continuous_callback(cb::Nothing) = false#======================================================##======================================================#
+has_continuous_callback(cb::Nothing) = false
 
 # Callback handling
 
@@ -478,7 +478,7 @@ function find_callback_time(integrator, callback::VectorContinuousCallback, coun
                 bottom_t = integrator.tprev
             end
             if callback.rootfind != SciMLBase.NoRootFind && !isdiscrete(integrator.alg)
-                min_t = nextfloat(top_t)
+                min_t = isone(integrator.tdir) ? nextfloat(top_t) : prevfloat(top_t)
                 min_event_idx = -1
                 for idx in 1:length(event_idx)
                     if ArrayInterface.allowed_getindex(event_idx, idx) != 0


### PR DESCRIPTION
## Checklist

- [x ] Appropriate tests were added: https://github.com/SciML/OrdinaryDiffEq.jl/pull/2809
- [x ] Any code changes were done in a way that does not break public API
- [ x] All documentation related to code changes were updated
- [x ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x ] Any new documentation only uses public API
  
## Additional context

Fix for https://github.com/SciML/DiffEqBase.jl/issues/1184
