### PR TITLE
fix: fix `step!` without `dt` for `NullODEIntegrator`

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -693,7 +693,7 @@ function step!(integ::NullODEIntegrator, dt = nothing, stop_at_tdt = false)
     if !isnothing(dt)
         integ.t += dt
     else
-        integ.t = integ.sol[end]
+        integ.t = integ.sol.t[end]
     end
     return nothing
 end

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -95,3 +95,10 @@ end
     @test_nowarn SciMLBase.u_modified!(integ, Float64[])
     @test SciMLBase.successful_retcode(SciMLBase.check_error(integ))
 end
+
+@testset "`step!` without dt" begin
+    prob = ODEProblem(Returns(nothing), nothing, (0.0, 1.0))
+    integ = init(prob, Tsit5())
+    @test_nowarn step!(integ)
+    @test integ.t ≈ 1.0
+end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
