### PR TITLE
Remove unused test dependencies: MonteCarloMeasurements and BenchmarkTools

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -117,7 +117,6 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
-BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
@@ -125,7 +124,6 @@ ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
-MonteCarloMeasurements = "0987c9cc-fe09-11e8-30f0-b96dd679fdca"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
@@ -138,4 +136,4 @@ Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Distributed", "Measurements", "MonteCarloMeasurements", "Unitful", "LabelledArrays", "ForwardDiff", "SparseArrays", "InteractiveUtils", "Pkg", "Random", "ReverseDiff", "StaticArrays", "SafeTestsets", "Statistics", "Test", "Distributions", "Aqua", "BenchmarkTools"]
+test = ["Distributed", "Measurements", "Unitful", "LabelledArrays", "ForwardDiff", "SparseArrays", "InteractiveUtils", "Pkg", "Random", "ReverseDiff", "StaticArrays", "SafeTestsets", "Statistics", "Test", "Distributions", "Aqua"]


### PR DESCRIPTION
## Summary
- Removes two completely unused test dependencies: `MonteCarloMeasurements` and `BenchmarkTools`
- Reduces test dependency footprint without affecting any functionality

## Analysis Performed
Conducted comprehensive analysis of all test files in the repository to identify unused dependencies:

### Dependencies Removed:
1. **BenchmarkTools** - No usage found anywhere in tests
   - No `@benchmark`, `@btime`, or `BenchmarkTools` imports in any test files
   - Removed from both `[extras]` and test targets

2. **MonteCarloMeasurements** - No usage found in tests  
   - Remains as weak dependency for the extension `DiffEqBaseMonteCarloMeasurementsExt`
   - Removed only from `[extras]` and test targets (not from `[weakdeps]`)

### Dependencies That Remain:
All other test dependencies are actively used across multiple test files:
- **Aqua**: Used in `aqua.jl`
- **ForwardDiff**: Used in 10+ test files for AD testing
- **StaticArrays**: Used in 5+ test files
- **Distributions**: Used in `high_level_solve.jl`
- **LabelledArrays**: Used in `downstream/labelledarrays.jl`
- **Measurements**: Used in `downstream/unwrapping.jl`
- **Distributed**: Used in `downstream/distributed_ensemble.jl`
- And many others...

## Test Plan
- [x] Verified package builds successfully after dependency removal
- [x] Confirmed no imports or usage of removed packages in any test files
- [x] Ensured `MonteCarloMeasurements` extension remains available as weak dependency

## Impact
- **Zero functional impact**: Removed packages were never used in tests
- **Reduced dependency footprint**: Two fewer packages to install for testing
- **Cleaner Project.toml**: Removes unused entries that could cause confusion

🤖 Generated with [Claude Code](https://claude.ai/code)