### PR TITLE
fixes tests that were broken by SciMLBase PR 1101

### DIFF
--- a/test/diffeqfunction_tests.jl
+++ b/test/diffeqfunction_tests.jl
@@ -1,4 +1,5 @@
 using DiffEqBase, Test, RecursiveArrayTools
+import SciMLBase: AbstractSciMLFunction
 
 macro iop_def(funcdef::Expr)
     """Define in- and out-of-place functions simultaneously.

--- a/test/diffeqfunction_tests.jl
+++ b/test/diffeqfunction_tests.jl
@@ -21,7 +21,7 @@ macro iop_def(funcdef::Expr)
     end
 end
 
-function test_inplace(du, expected, f::Function, args...)
+function test_inplace(du, expected, f::AbstractSciMLFunction, args...)
     """Test the in-place version of a function."""
     fill!(du, NaN)
     f(du, args...)
@@ -29,11 +29,11 @@ function test_inplace(du, expected, f::Function, args...)
 end
 
 # Allocate du automatically based on type of expected result
-function test_inplace(expected, f::Function, args...)
+function test_inplace(expected, f::AbstractSciMLFunction, args...)
     test_inplace(similar(expected), expected, f, args...)
 end
 
-function test_iop(expected, f_op::Function, f_ip::Function, args...)
+function test_iop(expected, f_op::AbstractSciMLFunction, f_ip::AbstractSciMLFunction, args...)
     """Test in- and out-of-place version of function both match expected value."""
     @test f_op(args...) == expected
     test_inplace(expected, f_ip, args...)


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

https://github.com/SciML/SciMLBase.jl/pull/1101 made it so that `(SciMLBase.AbstractSciMLFunction <: Function) == false` which broke tests here. This makes those tests working again.
