### PR TITLE
Remove unused Statistics.jl dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,6 @@ SciMLStructures = "53ae85a6-f571-4167-b2af-e1d143709226"
 Setfield = "efcf1570-3423-57d1-acb7-fd33fddbac46"
 Static = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
 StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
 TruncatedStacktraces = "781d530d-4396-4725-bb49-402e4bee1e77"
 
@@ -102,7 +101,6 @@ Setfield = "1"
 SparseArrays = "1.9"
 Static = "1"
 StaticArraysCore = "1.4"
-Statistics = "1"
 SymbolicIndexingInterface = "0.3.39"
 Tracker = "0.2"
 TruncatedStacktraces = "1"
@@ -124,10 +122,9 @@ ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Tracker = "9f7883ad-71c0-57eb-9f7f-b5c9e6d3789c"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
-test = ["Distributed", "Measurements", "Unitful", "LabelledArrays", "ForwardDiff", "SparseArrays", "InteractiveUtils", "Pkg", "Random", "ReverseDiff", "StaticArrays", "SafeTestsets", "Statistics", "Test", "Distributions", "Aqua"]
+test = ["Distributed", "Measurements", "Unitful", "LabelledArrays", "ForwardDiff", "SparseArrays", "InteractiveUtils", "Pkg", "Random", "ReverseDiff", "StaticArrays", "SafeTestsets", "Test", "Distributions", "Aqua"]

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -21,7 +21,6 @@ using FunctionWrappers: FunctionWrapper
 
 using MuladdMacro
 
-using Statistics
 
 using FastBroadcast: @.., True, False
 


### PR DESCRIPTION
## Summary
- Removes Statistics.jl as an unused dependency from DiffEqBase.jl
- Reduces the dependency footprint without any functionality loss

## Changes
- Removed `using Statistics` from src/DiffEqBase.jl (line 24)
- Removed Statistics from Project.toml dependencies, compat, extras, and test targets

## Testing
- Package compiles and loads successfully without Statistics
- No actual usage of Statistics functions was found in the codebase

Statistics.jl was imported but never actually used anywhere in DiffEqBase. This is part of a broader effort to reduce dependencies across the SciML stack.

🤖 Generated with [Claude Code](https://claude.ai/code)