### PR TITLE
feat: save discretes alongside callback save

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -131,3 +131,6 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [targets]
 test = ["Distributed", "Measurements", "Unitful", "LabelledArrays", "ForwardDiff", "SparseArrays", "InteractiveUtils", "Pkg", "Random", "ReverseDiff", "StaticArrays", "SafeTestsets", "Statistics", "Test", "Distributions", "Aqua"]
+
+[sources]
+SciMLBase = { url = "https://github.com/AayushSabharwal/SciMLBase.jl", rev = "as/callback-save" }

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -596,6 +596,11 @@ function apply_callback!(integrator,
 
         @inbounds if callback.save_positions[2]
             savevalues!(integrator, true)
+            if callback isa VectorContinuousCallback
+                SciMLBase.save_discretes!(integrator, callback, event_idx)
+            else
+                SciMLBase.save_discretes!(integrator, callback)
+            end
             saved_in_cb = true
         end
         return true, saved_in_cb
@@ -622,6 +627,7 @@ end
         end
         @inbounds if callback.save_positions[2]
             savevalues!(integrator, true)
+            SciMLBase.save_discretes!(integrator, callback)
             saved_in_cb = true
         end
     end


### PR DESCRIPTION
Requires https://github.com/SciML/SciMLBase.jl/pull/1116
The above PR is added to `[sources]` to be able to run CI and ensure backward compatibility.