### PR TITLE
Remove solve dispatches for EnsembleProblem, WeightedEnsembleProblem

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -1221,17 +1221,6 @@ function solve_call(prob::SteadyStateProblem,
         kwargs...)
 end
 
-function solve(prob::EnsembleProblem, args...; kwargs...)
-    alg = extract_alg(args, kwargs, kwargs)
-    if length(args) > 1
-        __solve(prob, alg, Base.tail(args)...; kwargs...)
-    else
-        __solve(prob, alg; kwargs...)
-    end
-end
-function solve(prob::SciMLBase.WeightedEnsembleProblem, args...; kwargs...)
-    SciMLBase.WeightedEnsembleSolution(solve(prob.ensembleprob), prob.weights)
-end
 function solve(prob::AbstractNoiseProblem, args...; kwargs...)
     __solve(prob, args...; kwargs...)
 end


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

These should probably go in SciMLBase since they can be composed of NonlinearProblems as well. Part of the migration towards seperating NonlinearSolve from DiffEqBase. 

Needs 
https://github.com/SciML/SciMLBase.jl/pull/1117
to fully work, otherwise EnsembleProblems won't solve. 