### PR TITLE
Improve progress bar docstring with VS Code setup link

### DIFF
--- a/src/solve.jl
+++ b/src/solve.jl
@@ -489,6 +489,8 @@ explanations of the timestepping algorithms, see the
 ### Progress Monitoring
 
 These arguments control the usage of the progressbar in ProgressLogging.jl compatible environments.
+For information on setting up progress bars in VS Code and other environments, see the
+[progress bar documentation](https://docs.sciml.ai/DiffEqDocs/stable/features/progress_bar/#Using-Progress-Bars-with-VS-Code).
 
 * `progress`: Turns on/off the Juno progressbar. Default is false.
 * `progress_steps`: Numbers of steps between updates of the progress bar.


### PR DESCRIPTION
## Summary

- Added reference to progress bar setup documentation in the Progress Monitoring section of the `solve()` docstring
- Addresses issue #1198 where users need guidance on setting up progress bars in VS Code and other environments
- Links directly to the specific documentation section that explains ProgressLogging.jl setup

## Background

Issue #1198 reported that `progress=true` wasn't displaying anything, and the solution was to use ProgressLogging.jl as documented. The request was made to add this link to the solver keyword descriptions to help users find the setup information more easily.

## Changes

- Modified `src/solve.jl` to include a link to https://docs.sciml.ai/DiffEqDocs/stable/features/progress_bar/#Using-Progress-Bars-with-VS-Code in the Progress Monitoring section
- The link provides comprehensive instructions for setting up progress bars in VS Code and other ProgressLogging.jl compatible environments

## Test Plan

- [x] Ran `julia --project=. -e 'using Pkg; Pkg.activate("."); Pkg.test()'` - all tests pass
- [x] Verified docstring changes don't break any existing functionality
- [x] Confirmed the link works and points to the correct documentation section

🤖 Generated with [Claude Code](https://claude.ai/code)