### PR TITLE
Add `promote_tspan` back to ForwardDiffExt

### DIFF
--- a/ext/DiffEqBaseForwardDiffExt.jl
+++ b/ext/DiffEqBaseForwardDiffExt.jl
@@ -90,6 +90,24 @@ function wrapfun_iip(@nospecialize(ff))
     FunctionWrappersWrappers.FunctionWrappersWrapper{typeof(fwt), false}(fwt)
 end
 
+function promote_tspan(u0::AbstractArray{<:ForwardDiff.Dual}, p, tspan, prob, kwargs)
+    if (haskey(kwargs, :callback) && has_continuous_callback(kwargs[:callback])) ||
+       (haskey(prob.kwargs, :callback) && has_continuous_callback(prob.kwargs[:callback]))
+        return _promote_tspan(eltype(u0).(tspan), kwargs)
+    else
+        return _promote_tspan(tspan, kwargs)
+    end
+end
+
+function promote_tspan(u0::AbstractArray{<:Complex{<:ForwardDiff.Dual}}, p, tspan, prob,
+        kwargs)
+    return _promote_tspan(real(eltype(u0)).(tspan), kwargs)
+end
+
+function promote_tspan(u0::AbstractArray{<:ForwardDiff.Dual}, p,
+        tspan::Tuple{<:ForwardDiff.Dual, <:ForwardDiff.Dual}, prob, kwargs)
+    return _promote_tspan(tspan, kwargs)
+end
 # Copy of the other prob2dtmin dispatch, just for optionality
 function prob2dtmin(tspan, ::ForwardDiff.Dual, use_end_time)
     t1, t2 = tspan


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

Fixes https://github.com/SciML/OrdinaryDiffEq.jl/issues/2867