### PR TITLE
Document initializealg keyword argument in solve docstring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.189.1"
+version = "6.190.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -434,6 +434,15 @@ explanations of the timestepping algorithms, see the
 * `callback`: Specifies a callback. Defaults to a callback function which
   performs the saving routine. For more information, see the
   [Event Handling and Callback Functions manual page](https://docs.sciml.ai/DiffEqCallbacks/stable/).
+* `initializealg`: The initialization algorithm for DAEs and ODEs with constraints.
+  Available options include:
+  - `DefaultInit()` (default): Automatically chooses the best initialization algorithm
+  - `CheckInit()`: Only checks that initial conditions are consistent, errors if not
+  - `NoInit()`: Skip initialization completely (for when you know conditions are consistent)
+  - `BrownBasicInit()`: Brown's basic initialization algorithm for index-1 DAEs
+  - `ShampineCollocationInit()`: Shampine's collocation initialization for general DAEs
+  See the [DAE initialization documentation](https://docs.sciml.ai/DiffEqDocs/stable/features/dae_initialization/)
+  for more details.
 * `isoutofdomain`: Specifies a function `isoutofdomain(u,p,t)` where, when it
   returns true, it will reject the timestep. Disabled by default.
 * `unstable_check`: Specifies a function `unstable_check(dt,u,p,t)` where, when


### PR DESCRIPTION
## Summary

This PR adds documentation for the `initializealg` keyword argument to the `solve` function docstring, following up on PR #1212 which added the initialization algorithm types.

## Changes

Added `initializealg` to the Miscellaneous section of the solve docstring with:
- Description of what it controls (DAE/ODE initialization)
- List of available algorithms with brief descriptions
- Reference to the full DAE initialization documentation

## Available Algorithms

- `DefaultInit()` (default): Automatically chooses the best initialization algorithm
- `CheckInit()`: Only checks that initial conditions are consistent, errors if not
- `NoInit()`: Skip initialization completely (for when you know conditions are consistent)
- `BrownBasicInit()`: Brown's basic initialization algorithm for index-1 DAEs
- `ShampineCollocationInit()`: Shampine's collocation initialization for general DAEs

## Related

- Initial algorithm types PR: #1212
- OrdinaryDiffEq PR: https://github.com/SciML/OrdinaryDiffEq.jl/pull/2873
- Sundials PR: https://github.com/SciML/Sundials.jl/pull/505

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>