### PR TITLE
Remove BrownBasicInit alias, keep only BrownFullBasicInit

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.190.1"
+version = "6.190.2"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/dae_initialization.jl
+++ b/src/dae_initialization.jl
@@ -20,9 +20,9 @@ For Sundials, this will use:
 struct DefaultInit <: DAEInitializationAlgorithm end
 
 """
-    struct BrownBasicInit{T, F} <: DAEInitializationAlgorithm
+    struct BrownFullBasicInit{T, F} <: DAEInitializationAlgorithm
 
-The Brown basic initialization algorithm for DAEs. This implementation
+The Brown full basic initialization algorithm for DAEs. This implementation
 is based on the algorithm described in:
 
 Peter N. Brown, Alan C. Hindmarsh, and Linda R. Petzold,
@@ -43,17 +43,14 @@ variables.
 - `abstol`: Absolute tolerance for the nonlinear solver (default: 1e-10)
 - `nlsolve`: Custom nonlinear solver to use (optional)
 """
-struct BrownBasicInit{T, F} <: DAEInitializationAlgorithm
+struct BrownFullBasicInit{T, F} <: DAEInitializationAlgorithm
     abstol::T
     nlsolve::F
 end
-function BrownBasicInit(; abstol = 1e-10, nlsolve = nothing)
-    BrownBasicInit(abstol, nlsolve)
+function BrownFullBasicInit(; abstol = 1e-10, nlsolve = nothing)
+    BrownFullBasicInit(abstol, nlsolve)
 end
-BrownBasicInit(abstol) = BrownBasicInit(; abstol = abstol, nlsolve = nothing)
-
-# Alias for consistency with OrdinaryDiffEq naming
-const BrownFullBasicInit = BrownBasicInit
+BrownFullBasicInit(abstol) = BrownFullBasicInit(; abstol = abstol, nlsolve = nothing)
 
 """
     struct ShampineCollocationInit{T, F} <: DAEInitializationAlgorithm
@@ -89,4 +86,4 @@ function ShampineCollocationInit(initdt)
     ShampineCollocationInit(; initdt = initdt, nlsolve = nothing)
 end
 
-export DefaultInit, BrownBasicInit, BrownFullBasicInit, ShampineCollocationInit
+export DefaultInit, BrownFullBasicInit, ShampineCollocationInit


### PR DESCRIPTION
## Summary
- Remove the `BrownBasicInit` alias and keep only `BrownFullBasicInit` as the primary struct name
- Simplifies the API by having a single name for this initialization algorithm
- Bump version to 6.190.2

## Changes
- Changed `struct BrownBasicInit` to `struct BrownFullBasicInit` 
- Removed the `const BrownFullBasicInit = BrownBasicInit` alias line
- Updated exports to only export `BrownFullBasicInit`
- Updated docstring to reflect the new name

This is a breaking change for code that uses `BrownBasicInit` directly, but maintains compatibility for code using `BrownFullBasicInit`.

Related to ongoing work in OrdinaryDiffEq and Sundials packages to use the extended initialization algorithms from DiffEqBase.