### PR TITLE
Use SciMLBase.set_mooncakeoriginator_if_mooncake instead of local definition

### DIFF
--- a/ext/DiffEqBaseChainRulesCoreExt.jl
+++ b/ext/DiffEqBaseChainRulesCoreExt.jl
@@ -2,8 +2,7 @@ module DiffEqBaseChainRulesCoreExt
 
 using DiffEqBase
 using DiffEqBase.SciMLBase
-import DiffEqBase: numargs, AbstractSensitivityAlgorithm, AbstractDEProblem,
-                   set_mooncakeoriginator_if_mooncake
+import DiffEqBase: numargs, AbstractSensitivityAlgorithm, AbstractDEProblem
 
 import ChainRulesCore
 import ChainRulesCore: NoTangent

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -543,11 +543,11 @@ function solve(prob::AbstractDEProblem, args...; sensealg = nothing,
 
     if wrap isa Val{true}
         wrap_sol(solve_up(prob, sensealg, u0, p, args...;
-            originator = set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
+            originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
             kwargs...))
     else
         solve_up(prob, sensealg, u0, p, args...;
-            originator = set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
+            originator = SciMLBase.set_mooncakeoriginator_if_mooncake(SciMLBase.ChainRulesOriginator()),
             kwargs...)
     end
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -30,8 +30,6 @@ timedepentdtmin(::Any, dtmin) = abs(dtmin)
 
 maybe_with_logger(f, logger) = logger === nothing ? f() : Logging.with_logger(f, logger)
 
-set_mooncakeoriginator_if_mooncake(x::SciMLBase.ADOriginator) = x
-
 function default_logger(logger)
     Logging.min_enabled_level(logger) ≤ ProgressLogging.ProgressLevel && return nothing
 


### PR DESCRIPTION
## Summary

- Removes the local `set_mooncakeoriginator_if_mooncake` definition from `utils.jl` that lacked Mooncake extension support
- Updates `solve.jl` to use `SciMLBase.set_mooncakeoriginator_if_mooncake` which has the proper Mooncake override in `SciMLBaseMooncakeExt.jl`
- Removes the unused import from `DiffEqBaseChainRulesCoreExt.jl`

## Problem

DiffEqBase defined its own `set_mooncakeoriginator_if_mooncake` function in `utils.jl`, separate from SciMLBase's version. While SciMLBase's version has a proper Mooncake extension override that converts `ChainRulesOriginator` to `MooncakeOriginator`, DiffEqBase's version did not.

This caused the `originator` to remain as `ChainRulesOriginator` when using Mooncake AD, which led to SciMLSensitivity test failures where `MooncakeTrackedRealError` was expected but `TypeError` was thrown instead.

## Test plan

- [ ] Verify SciMLSensitivity `alternative_ad_frontend.jl` tests pass with Mooncake
- [ ] Verify existing DiffEqBase tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)