### PR TITLE
Documentation improvements: Fix typos and update outdated link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,6 @@ DiffEqBase.jl is a component package in the DiffEq ecosystem. It holds the
 common types and utility functions which are shared by other solver packages
 to promote code reuse in the differential equation solver code.
 Users interested in using this
-functionality in full should check out [DifferentialEquations.jl](https://github.com/JuliaDiffEq/DifferentialEquations.jl)
+functionality in full should check out [DifferentialEquations.jl](https://github.com/SciML/DifferentialEquations.jl).
 
 The documentation for the interfaces here can be found in [DiffEqDocs.jl](https://docs.sciml.ai/DiffEqDocs/dev/) and [DiffEqDevDocs.jl](https://docs.sciml.ai/DiffEqDevDocs/dev/).

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -429,7 +429,7 @@ function find_callback_time(integrator, callback::ContinuousCallback, counter)
                         bottom_t += integrator.dt * callback.repeat_nudge
                         sign_top = sign(zero_func(top_t))
                         sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) &&
-                            error("Double callback crossing floating pointer reducer errored. Report this issue.")
+                            error("Double callback crossing floating point reducer errored. Report this issue.")
                     end
                     Θ = bisection(zero_func, (bottom_t, top_t), isone(integrator.tdir),
                         callback.rootfind, callback.abstol, callback.reltol)
@@ -437,7 +437,7 @@ function find_callback_time(integrator, callback::ContinuousCallback, counter)
                         zero_func(Θ), Θ))
                 end
                 #Θ = prevfloat(...)
-                # prevfloat guerentees that the new time is either 1 floating point
+                # prevfloat guarantees that the new time is either 1 floating point
                 # numbers just before the event or directly at zero, but not after.
                 # If there's a barrier which is never supposed to be crossed,
                 # then this will ensure that
@@ -503,7 +503,7 @@ function find_callback_time(integrator, callback::VectorContinuousCallback, coun
                                 bottom_t += integrator.dt * callback.repeat_nudge
                                 sign_top = sign(zero_func(top_t))
                                 sign(zero_func(bottom_t)) * sign_top >= zero(sign_top) &&
-                                    error("Double callback crossing floating pointer reducer errored. Report this issue.")
+                                    error("Double callback crossing floating point reducer errored. Report this issue.")
                             end
 
                             Θ = bisection(zero_func, (bottom_t, top_t),
@@ -521,7 +521,7 @@ function find_callback_time(integrator, callback::VectorContinuousCallback, coun
                     end
                 end
                 #Θ = prevfloat(...)
-                # prevfloat guerentees that the new time is either 1 floating point
+                # prevfloat guarantees that the new time is either 1 floating point
                 # numbers just before the event or directly at zero, but not after.
                 # If there's a barrier which is never supposed to be crossed,
                 # then this will ensure that

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -537,7 +537,7 @@ the extension to other types is straightforward.
    for accurate output at specified (and equidistant) time intervals, used for
    e.g. Fourier Transform. The solution is given every 0.01 time units,
    starting from `tspan[1]`. The solver used is `Tsit5()` since no keyword
-   `alg_hits` is given.
+   `alg_hints` is given.
 
 3. `solve(prob, maxiters = 1e7, progress = true, save_idxs = [1])` : Using longer
    maximum number of solver iterations can be useful when a given `tspan` is very

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -7,7 +7,7 @@ function prob2dtmin(prob; use_end_time = true)
     prob2dtmin(prob.tspan, oneunit(eltype(prob.tspan)), use_end_time)
 end
 
-# This functino requires `eps` to exist, which restricts below `<: Real`
+# This function requires `eps` to exist, which restricts below `<: Real`
 # Example of a failure is Rational
 function prob2dtmin(tspan, ::AbstractFloat, use_end_time)
     t1, t2 = tspan


### PR DESCRIPTION
## Summary

- Fix outdated DifferentialEquations.jl link in README.md (JuliaDiffEq → SciML)
- Fix typo "functino" → "function" in src/utils.jl comment
- Fix typo "alg_hits" → "alg_hints" in src/solve.jl docstring
- Fix typo "floating pointer" → "floating point" in src/callbacks.jl error messages
- Fix typo "guerentees" → "guarantees" in src/callbacks.jl comments

## Test plan

- [x] Changes are documentation/typo fixes only - no functional code changes
- [x] All typos verified manually

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)