### PR TITLE
Bump version to 6.195.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.194.0"
+version = "6.195.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
## Version Bump

Bumping version from 6.194.0 to 6.195.0 to prepare for release.

### Changes since last release (v6.194.0)

- Merge pull request #1248 from SciML/dependabot/github_actions/actions/checkout-6
- Bump actions/checkout from 4 to 6
- Merge pull request #1247 from ChrisRackauckas-Claude/runic-formatting
- Switch from JuliaFormatter to Runic.jl for code formatting
- Merge pull request #1246 from ChrisRackauckas-Claude/precompile-improvements-20260103-064419
- Add precompilation workload for common operations
- Merge pull request #1234 from dcourteville/fix_1233
- Downgrade BracketingNonlinearSolve to version 1.6.2
- Update to BracketingNonlinearSolve 1.6.3
- Merge pull request #1195 from ChrisRackauckas-Claude/remove-statistics-dep
- Fix Statistics usage in ensemble tests
- Merge pull request #1242 from ChrisRackauckas-Claude/docs-improvements-20251229-112935
- Fix typos and update outdated link in documentation
- Replace internal ITP with NonlinearSolve ITP
- Fix left/right rootfinding for backward propagation
- Remove unused Statistics.jl dependency

### Registration Commands

After merging, register with:

@JuliaRegistrator register

cc @ChrisRackauckas