### PR TITLE
Import DEFAULT_UPDATE_FUNC from SciMLOperators instead of SciMLBase

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -41,7 +41,7 @@ import FunctionWrappersWrappers
 
 using SciMLBase
 
-using SciMLOperators: AbstractSciMLOperator, AbstractSciMLScalarOperator
+using SciMLOperators: AbstractSciMLOperator, AbstractSciMLScalarOperator, DEFAULT_UPDATE_FUNC
 
 using SciMLBase: @def, DEIntegrator, AbstractDEProblem,
     AbstractDiffEqInterpolation,
@@ -86,7 +86,7 @@ using SciMLBase: @def, DEIntegrator, AbstractDEProblem,
     interp_summary, AbstractHistoryFunction, LinearInterpolation,
     ConstantInterpolation, HermiteInterpolation, SensitivityInterpolation,
     NoAD, @add_kwonly,
-    calculate_ensemble_errors, DEFAULT_UPDATE_FUNC, isconstant,
+    calculate_ensemble_errors, isconstant,
     DEFAULT_REDUCTION, isautodifferentiable,
     isadaptive, isdiscrete, has_syms, AbstractAnalyticalSolution,
     RECOMPILE_BY_DEFAULT, wrap_sol, has_destats


### PR DESCRIPTION
## Summary
- Import `DEFAULT_UPDATE_FUNC` directly from `SciMLOperators` where it is defined
- Remove the import from `SciMLBase` which was re-exporting it

## Motivation
This change is needed to maintain compatibility with SciML/SciMLBase.jl#1203 which improves explicit imports hygiene. That PR removes the transitive re-export of `DEFAULT_UPDATE_FUNC` from `SciMLBase`, so downstream packages need to import it directly from `SciMLOperators`.

## Test plan
- [x] Verify `DEFAULT_UPDATE_FUNC` is exported by `SciMLOperators`
- [ ] CI tests should pass with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)