### PR TITLE
Remove unused EnzymeCore strong dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,14 +1,13 @@
 name = "DiffEqBase"
 uuid = "2b5f629d-d688-5b77-993f-72d75c75574e"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "6.199.0"
+version = "6.200.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
 BracketingNonlinearSolve = "70df07ce-3d50-431d-a3e7-ca6ddb60ac1e"
 ConcreteStructs = "2569d6c7-a4a2-43d3-a901-331e8e4be471"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-EnzymeCore = "f151be2c-9106-41f4-ab19-57ee4f262869"
 FastBroadcast = "7034ab61-46d4-4ed7-9d0f-46aef9175898"
 FastClosures = "9aa1b823-49e4-5ca5-8b0f-3971ec8bab6a"
 FastPower = "a4df4552-cc26-4903-aec0-212e50a0e84b"
@@ -75,7 +74,6 @@ DifferentiationInterface = "0.7"
 Distributions = "0.25"
 DocStringExtensions = "0.9"
 Enzyme = "0.13.100"
-EnzymeCore = "0.7, 0.8"
 FastBroadcast = "0.3.5"
 FastClosures = "0.3.2"
 FastPower = "1.1"


### PR DESCRIPTION
## Summary
- Remove `EnzymeCore` from `[deps]` — it was never imported or used in any source file
- Remove the now-dangling `[compat]` entry for `EnzymeCore`
- Bump version to 6.200.0

## Motivation
EnzymeCore as a strong dependency forces it to be installed for all DiffEqBase users. This causes OrdinaryDiffEqCore's `EnzymeCoreExt` extension to trigger unconditionally. Combined with the always-available `SparseArrays` stdlib triggering `SparseArraysExt`, Julia 1.10's precompilation system detects a circular dependency between the two extensions, preventing precompilation and causing errors when loading with EnzymeCore.

See SciML/OrdinaryDiffEq.jl#3025

Fixes SciML/OrdinaryDiffEq.jl#3025

## Test plan
- [x] `Pkg.test()` passes locally
- [x] `using DiffEqBase` loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)