### PR TITLE
Fix deprecation and method redefinition warnings in CI tests

### DIFF
--- a/test/downstream/community_callback_tests.jl
+++ b/test/downstream/community_callback_tests.jl
@@ -153,7 +153,7 @@ function condition(out, u, t, integrator)
     return
 end
 
-function affect!(integrator, idx)
+function collision_affect!(integrator, idx)
     i = 0
     u = integrator.u
     n = length(u.nodes)
@@ -191,7 +191,7 @@ end
 
 cback = VectorContinuousCallback(
     condition,
-    affect!,
+    collision_affect!,
     (x -> Int(((x - 1) * x) / 2))(length(Newton.nodes))
 )
 
@@ -217,10 +217,10 @@ function cond!(out, u, t, i)
     out[1] = u[3]
     return nothing
 end
-function affect!(int, idx)
+function terminate_affect!(int, idx)
     return terminate!(int)
 end
-cb = VectorContinuousCallback(cond!, affect!, nothing, 1)
+cb = VectorContinuousCallback(cond!, terminate_affect!, nothing, 1)
 
 u0 = [0.0, 0.0, 1.0]
 prob = ODEProblem(f!, u0, (0.0, 10.0); callback = cb)

--- a/test/downstream/default_linsolve_structure.jl
+++ b/test/downstream/default_linsolve_structure.jl
@@ -39,19 +39,19 @@ sol = solve(prob,Rosenbrock23())
 # LoadError: ArgumentError: broadcasted assignment breaks symmetry between locations (1, 2) and (2, 1)
 
 @test_broken begin
-    jp = Hermitian(jp_diag)
-    fun = ODEFunction(f; jac = jac, jac_prototype = jp)
-    prob = ODEProblem(fun, ones(2), (1.0, 10.0))
-    sol = solve(prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
+    local jp = Hermitian(jp_diag)
+    local fun = ODEFunction(f; jac = jac, jac_prototype = jp)
+    local prob = ODEProblem(fun, ones(2), (1.0, 10.0))
+    local sol = solve(prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
     @test sol.u[end] ≈ [10.0, 10.0]
     @test length(sol) < 60
 end
 
 @test_broken begin
-    jp = Symmetric(jp_diag)
-    fun = ODEFunction(f; jac = jac, jac_prototype = jp)
-    prob = ODEProblem(fun, ones(2), (1.0, 10.0))
-    sol = solve(prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
+    local jp = Symmetric(jp_diag)
+    local fun = ODEFunction(f; jac = jac, jac_prototype = jp)
+    local prob = ODEProblem(fun, ones(2), (1.0, 10.0))
+    local sol = solve(prob, Rosenbrock23(autodiff = AutoFiniteDiff()))
     @test sol.u[end] ≈ [10.0, 10.0]
     @test length(sol) < 60
 end

--- a/test/downstream/distributed_ensemble.jl
+++ b/test/downstream/distributed_ensemble.jl
@@ -10,13 +10,13 @@ println("There are $(nprocs()) processes")
     using OrdinaryDiffEq
     prob = ODEProblem((u, p, t) -> 1.01u, 0.5, (0.0, 1.0))
     u0s = [rand() * prob.u0 for i in 1:2]
-    function prob_func(prob, i, repeat)
+    function simple_prob_func(prob, i, repeat)
         println("Running trajectory $i")
         ODEProblem(prob.f, u0s[i], prob.tspan)
     end
 end
 
-ensemble_prob = EnsembleProblem(prob, prob_func = prob_func)
+ensemble_prob = EnsembleProblem(prob, prob_func = simple_prob_func)
 sim = solve(ensemble_prob, Tsit5(), EnsembleSplitThreads(), trajectories = 2)
 
 @everywhere function lorenz!(du, u, p, t)
@@ -30,12 +30,12 @@ tspan = (0.0, 100.0)
 p = [1, 2.0, 3]
 prob = ODEProblem(lorenz!, u0, tspan, p)
 
-@everywhere function prob_func(prob, i, repeat)
+@everywhere function lorenz_prob_func(prob, i, repeat)
     prob = remake(prob, tspan = (rand(), 100.0), p = rand(3))
     return prob
 end
 
-ensemble_prob = EnsembleProblem(prob, prob_func = prob_func, safetycopy = true)
+ensemble_prob = EnsembleProblem(prob, prob_func = lorenz_prob_func, safetycopy = true)
 
 println("Running EnsembleSerial()")
 @test length(solve(ensemble_prob, Tsit5(), EnsembleSerial(), trajectories = 100)) == 100

--- a/test/downstream/kwarg_warn.jl
+++ b/test/downstream/kwarg_warn.jl
@@ -13,7 +13,7 @@ sol = solve(prob, Tsit5(), rel_tol = 1.0e-6, kwargshandle = SciMLBase.KeywordArg
 @test_logs (:warn, SciMLBase.KWARGWARN_MESSAGE) sol = solve(
     prob, Tsit5(), rel_tol = 1.0e-6, kwargshandle = SciMLBase.KeywordArgWarn
 )
-@test_throws SciMLBase.CommonKwargError sol = solve(prob, Tsit5(), rel_tol = 1.0e-6)
+@test_throws SciMLBase.CommonKwargError solve(prob, Tsit5(), rel_tol = 1.0e-6)
 
 prob = ODEProblem(lorenz, u0, tspan, test = 2.0, kwargshandle = SciMLBase.KeywordArgWarn)
 @test_logs (:warn, SciMLBase.KWARGWARN_MESSAGE) sol = solve(prob, Tsit5(), reltol = 1.0e-6)

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -38,8 +38,8 @@ eqs = [
     0 ~ y - x
 ]
 
-@named sys = ODESystem(eqs, t)
-sys = structural_simplify(sys)
+@named sys = System(eqs, t)
+sys = mtkcompile(sys)
 
 prob = ODEProblem(sys, Pair[], (0, 10.0))
 sol = solve(prob, Tsit5())
@@ -53,10 +53,10 @@ for kwargs in [
         Dict(:save_start => false),
         Dict(:save_end => false),
     ]
-    sol = solve(prob, kwargs...)
-    init_integ = init(prob, kwargs...)
+    local sol = solve(prob, kwargs...)
+    local init_integ = init(prob, kwargs...)
     solve!(init_integ)
-    step_integ = init(prob, kwargs...)
+    local step_integ = init(prob, kwargs...)
     step!(step_integ, prob.tspan[end] - prob.tspan[begin])
     @test sol.u[end] == init_integ.u
     @test sol.t[end] == init_integ.t
@@ -70,8 +70,8 @@ eqs = [
     0 ~ y - x
 ]
 
-@named sys = NonlinearSystem(eqs, [x, y], [])
-sys = structural_simplify(sys)
+@named sys = System(eqs, [x, y], [])
+sys = mtkcompile(sys)
 prob = NonlinearProblem(sys, [])
 
 sol = solve(prob, DynamicSS(Tsit5()))
@@ -96,14 +96,14 @@ sol = solve(unsatprob) # Success
     @parameters P
     @variables x(t)
     # numerical ODE: x′(t) = P with x(0) = 0
-    sys_num = structural_simplify(ODESystem([D(x) ~ P], t, [x], [P]; name = :sys))
+    sys_num = mtkcompile(System([D(x) ~ P], t, [x], [P]; name = :sys))
     prob_num_uninit = ODEProblem(sys_num, [x => 0.0], (0.0, 1.0), [P => NaN]) # uninitialized problem
     x_at_1_num(P) = solve(remake(prob_num_uninit; p = [sys_num.P => P]), Tsit5())(
         1.0, idxs = x
     )
 
     # analytical solution: x(t) = P*t
-    sys_anal = structural_simplify(ODESystem([x ~ P * t], t, [x], [P]; name = :sys))
+    sys_anal = mtkcompile(System([x ~ P * t], t, [x], [P]; name = :sys))
     prob_anal_uninit = ODEProblem(sys_anal, [], (0.0, 1.0), [P => NaN])
     x_at_1_anal(P) = solve(remake(prob_anal_uninit; p = [sys_anal.P => P]), Tsit5())(
         1.0, idxs = x

--- a/test/downstream/solve_error_handling.jl
+++ b/test/downstream/solve_error_handling.jl
@@ -1,49 +1,49 @@
 using OrdinaryDiffEq, StochasticDiffEq, Test, Sundials
 
-f(u, p, t) = 2u
+f_oop(u, p, t) = 2u
 u0 = 0.5
 tspan = (0.0, 1.0)
-prob = ODEProblem(f, u0, tspan)
+prob = ODEProblem(f_oop, u0, tspan)
 sol = solve(prob, Tsit5())
 
-function f(du, u, p, t)
+function f_iip(du, u, p, t)
     return du .= 2.0 * u
 end
-prob = ODEProblem(f, u0, tspan)
-@test_throws SciMLBase.IncompatibleInitialConditionError sol = solve(prob, Tsit5())
+prob = ODEProblem(f_iip, u0, tspan)
+@test_throws SciMLBase.IncompatibleInitialConditionError solve(prob, Tsit5())
 
-prob = ODEProblem{false}(f, u0, tspan)
+prob = ODEProblem{false}(f_oop, u0, tspan)
 sol = solve(prob, Tsit5())
 sol = solve(prob, nothing, alg = Tsit5())
 sol = init(prob, nothing, alg = Tsit5())
 
-prob = ODEProblem{false}(f, 1.0 + im, tspan)
+prob = ODEProblem{false}(f_oop, 1.0 + im, tspan)
 @test_throws SciMLBase.ComplexSupportError solve(prob, CVODE_Adams())
 
 @test_throws SciMLBase.ProblemSolverPairingError solve(prob, DFBDF())
 @test_throws SciMLBase.NonSolverError solve(prob, 5.0)
 
-prob = ODEProblem{false}(f, u0, (nothing, nothing))
+prob = ODEProblem{false}(f_oop, u0, (nothing, nothing))
 @test_throws SciMLBase.NoTspanError solve(prob, Tsit5())
 
-prob = ODEProblem{false}(f, u0, (NaN, 1.0))
+prob = ODEProblem{false}(f_oop, u0, (NaN, 1.0))
 @test_throws SciMLBase.NaNTspanError solve(prob, Tsit5())
 
-prob = ODEProblem{false}(f, u0, (1.0, NaN))
+prob = ODEProblem{false}(f_oop, u0, (1.0, NaN))
 @test_throws SciMLBase.NaNTspanError solve(prob, Tsit5())
 
-prob = ODEProblem{false}(f, Any[1.0, 1.0f0], tspan)
+prob = ODEProblem{false}(f_oop, Any[1.0, 1.0f0], tspan)
 @test_throws SciMLBase.NonConcreteEltypeError solve(prob, Tsit5())
 
-prob = ODEProblem{false}(f, (1.0, 1.0f0), tspan)
+prob = ODEProblem{false}(f_oop, (1.0, 1.0f0), tspan)
 @test_throws SciMLBase.TupleStateError solve(prob, Tsit5())
 
-prob = ODEProblem{false}(f, u0, (0.0 + im, 1.0))
+prob = ODEProblem{false}(f_oop, u0, (0.0 + im, 1.0))
 @test_throws SciMLBase.ComplexTspanError solve(prob, Tsit5())
 
 for u0 in ([0.0, 0.0], nothing)
-    fmm = ODEFunction(f, mass_matrix = zeros(3, 3))
-    prob = ODEProblem(fmm, u0, (0.0, 1.0))
+    local fmm = ODEFunction(f_oop, mass_matrix = zeros(3, 3))
+    local prob = ODEProblem(fmm, u0, (0.0, 1.0))
     @test_throws SciMLBase.IncompatibleMassMatrixError solve(prob, Tsit5())
 end
 
@@ -53,7 +53,7 @@ prob = ODEProblem(fmm, nothing, (0.0, 1.0))
 sol = solve(prob, Tsit5())
 @test isa(sol, SciMLBase.ODESolution)
 
-f(du, u, p, t) = du .= 1.01u
+f_sde(du, u, p, t) = du .= 1.01u
 function g(du, u, p, t)
     du[1, 1] = 0.3u[1]
     du[1, 2] = 0.6u[1]
@@ -66,7 +66,7 @@ function g(du, u, p, t)
 end
 
 prob = SDEProblem(
-    f,
+    f_sde,
     g,
     randn(ComplexF64, 2),
     (0.0, 1.0),

--- a/test/downstream/subarray_support.jl
+++ b/test/downstream/subarray_support.jl
@@ -17,7 +17,7 @@ using Test
         sol = solve(prob, Tsit5())
 
         @test sol.retcode == ReturnCode.Success
-        @test length(sol[end]) == 5
+        @test length(sol.u[end]) == 5
     end
 
     # Test 2: Simple pendulum with SubArray initial conditions
@@ -46,7 +46,7 @@ using Test
         # Solve and verify the solution
         sol = solve(prob, Tsit5(); reltol = 1.0e-6)
         @test sol.retcode == ReturnCode.Success
-        @test length(sol[end]) == 2
+        @test length(sol.u[end]) == 2
     end
 
     # Test 3: Various SubArray slicing patterns

--- a/test/forwarddiff_dual_detection.jl
+++ b/test/forwarddiff_dual_detection.jl
@@ -346,20 +346,20 @@ u0 = [1.0 + 1im, 2.0, 3.0]
 @test DiffEqBase.promote_u0(u0, p, t) isa AbstractArray{<:Complex{<:ForwardDiff.Dual}}
 
 # Issue https://github.com/SciML/NonlinearSolve.jl/issues/440
-f(u, p, t) = [u[2], 1.5u[1]^2]
-ode = ODEProblem(f, [0.0, 0.0], (0, 1))
+f_nlsolve(u, p, t) = [u[2], 1.5u[1]^2]
+ode = ODEProblem(f_nlsolve, [0.0, 0.0], (0, 1))
 @inferred DiffEqBase.anyeltypedual(ode)
-ode = NonlinearProblem(f, [0.0, 0.0], (0, 1))
+ode = NonlinearProblem(f_nlsolve, [0.0, 0.0], (0, 1))
 @inferred DiffEqBase.anyeltypedual(ode)
 
 # Issue https://github.com/SciML/DiffEqBase.jl/issues/1021
-f(u, p, t) = 1.01 * u
+f_1021(u, p, t) = 1.01 * u
 struct Foo{T}
     sol::T
 end
 u0 = 1 / 2
 tspan = (0.0, 1.0)
-prob = ODEProblem{false}(f, u0, tspan)
+prob = ODEProblem{false}(f_1021, u0, tspan)
 foo = SciMLBase.build_solution(
     prob, DiffEqBase.InternalEuler.FwdEulerAlg(), [u0, u0], [0.0, 1.0]
 )

--- a/test/problem_creation_tests.jl
+++ b/test/problem_creation_tests.jl
@@ -22,51 +22,51 @@ end
 p = (0.0, 1.0)
 prob = IntegralProblem(f_quad, (zeros(2), ones(2)), p)
 
-function f(du, u, p, t)
+function f_ode(du, u, p, t)
     du[1] = 0.2u[1]
     return du[2] = 0.4u[2]
 end
 u0 = ones(2)
 tspan = (0, 1.0)
 
-prob = ODEProblem(f, u0, tspan)
+prob = ODEProblem(f_ode, u0, tspan)
 @test typeof(prob.tspan) == Tuple{Float64, Float64}
-prob = ODEProblem{true}(f, u0, tspan)
+prob = ODEProblem{true}(f_ode, u0, tspan)
 @test typeof(prob.tspan) == Tuple{Float64, Float64}
-prob = ODEProblem(ODEFunction{true}(f), u0, tspan)
+prob = ODEProblem(ODEFunction{true}(f_ode), u0, tspan)
 @test typeof(prob.tspan) == Tuple{Float64, Float64}
 @test isinplace(prob) == true
-prob = ODEProblem{false}(f, u0, tspan)
+prob = ODEProblem{false}(f_ode, u0, tspan)
 @test isinplace(prob) == false
 
-@inferred ODEProblem{true}(f, u0, tspan)
-@test_broken @inferred(ODEProblem(f, u0, tspan)) == ODEProblem(f, u0, tspan)
+@inferred ODEProblem{true}(f_ode, u0, tspan)
+@test_broken @inferred(ODEProblem(f_ode, u0, tspan)) == ODEProblem(f_ode, u0, tspan)
 
-function f(dv, u, v, p, t)
+function f_2ndorder(dv, u, v, p, t)
     return dv .= 2.0 .* v
 end
 u0 = ones(2)
 v0 = ones(2)
 tspan = (0, 1.0)
-prob = SecondOrderODEProblem(f, u0, v0, tspan)
+prob = SecondOrderODEProblem(f_2ndorder, u0, v0, tspan)
 
 prob = SDEProblem((u, p, t) -> 1.01u, (u, p, t) -> 0.87u, 1 / 2, (0.0, 1.0))
 
-function f(du, u, p, t)
+function f_sde(du, u, p, t)
     du[1] = 0.2u[1]
     return du[2] = 0.4u[2]
 end
-function g(du, u, p, t)
+function g_sde(du, u, p, t)
     du[1] = 0.2u[1]
     return du[2] = 0.4u[2]
 end
 u0 = ones(2)
 tspan = (0, 1.0)
-prob = SDEProblem(f, g, u0, tspan)
-prob = SDEProblem{true}(f, g, u0, tspan)
+prob = SDEProblem(f_sde, g_sde, u0, tspan)
+prob = SDEProblem{true}(f_sde, g_sde, u0, tspan)
 
-@test_broken @inferred(SDEProblem(f, g, u0, tspan)) == SDEProblem(f, g, u0, tspan)
-@inferred SDEProblem{true}(f, g, u0, tspan)
+@test_broken @inferred(SDEProblem(f_sde, g_sde, u0, tspan)) == SDEProblem(f_sde, g_sde, u0, tspan)
+@inferred SDEProblem{true}(f_sde, g_sde, u0, tspan)
 
 f_1delay = function (du, u, h, p, t)
     return du[1] = -h(t - 1)[1]
@@ -91,7 +91,7 @@ prob = DDEProblem{true}(
     dependent_lags = ones(1)
 )
 
-function f(r, yp, y, p, tres)
+function f_dae(r, yp, y, p, tres)
     r[1] = -0.04 * y[1] + 1.0e4 * y[2] * y[3]
     r[2] = -r[1] - 3.0e7 * y[2] * y[2] - yp[2]
     r[1] -= yp[1]
@@ -101,42 +101,42 @@ u0 = [1.0, 0, 0]
 du0 = [-0.04, 0.04, 0.0]
 differential_vars = [true, true, false]
 
-prob_dae_resrob = DAEProblem(f, du0, u0, (0.0, 100000.0))
-prob_dae_resrob = DAEProblem{true}(f, du0, u0, (0.0, 100000.0))
+prob_dae_resrob = DAEProblem(f_dae, du0, u0, (0.0, 100000.0))
+prob_dae_resrob = DAEProblem{true}(f_dae, du0, u0, (0.0, 100000.0))
 
-@test_broken @inferred(DAEProblem(f, du0, u0, (0.0, 100000.0))) ==
-    DAEProblem(f, du0, u0, (0.0, 100000.0))
-@inferred DAEProblem{true}(f, du0, u0, (0.0, 100000.0))
+@test_broken @inferred(DAEProblem(f_dae, du0, u0, (0.0, 100000.0))) ==
+    DAEProblem(f_dae, du0, u0, (0.0, 100000.0))
+@inferred DAEProblem{true}(f_dae, du0, u0, (0.0, 100000.0))
 
 # Ensures uniform dimensionality of u0, du0, and differential_vars
-@test_throws ArgumentError DAEProblem(f, du0, u0[1:(end - 1)], (0.0, 100000.0))
+@test_throws ArgumentError DAEProblem(f_dae, du0, u0[1:(end - 1)], (0.0, 100000.0))
 @test_throws ArgumentError DAEProblem(
-    f, du0, u0, (0.0, 100000.0);
+    f_dae, du0, u0, (0.0, 100000.0);
     differential_vars = differential_vars[1:(end - 1)]
 )
 
-f(u, t, W) = 1.01u .+ 0.87u .* W
+f_rode(u, p, t, W) = 1.01u .+ 0.87u .* W
 u0 = 1.0
 tspan = (0.0, 1.0)
-prob = RODEProblem(f, u0, tspan)
-prob = RODEProblem{false}(f, u0, tspan)
+prob = RODEProblem(f_rode, u0, tspan)
+prob = RODEProblem{false}(f_rode, u0, tspan)
 
-@test_broken @inferred(RODEProblem(f, u0, tspan)) == RODEProblem(f, u0, tspan)
-@inferred RODEProblem{false}(f, u0, tspan)
+@test_broken @inferred(RODEProblem(f_rode, u0, tspan)) == RODEProblem(f_rode, u0, tspan)
+@inferred RODEProblem{false}(f_rode, u0, tspan)
 
 DiscreteProblem(ones(1), tspan)
-f(t, u) = 0.5
-DiscreteProblem{false}(f, ones(1), tspan)
+f_discrete(u, p, t) = 0.5
+DiscreteProblem{false}(f_discrete, ones(1), tspan)
 
 @test_broken @inferred(DiscreteProblem(ones(1), tspan)) == DiscreteProblem(ones(1), tspan)
-@inferred DiscreteProblem{false}(f, ones(1), tspan)
+@inferred DiscreteProblem{false}(f_discrete, ones(1), tspan)
 
-function f(du, u, t)
+function f_steady(du, u, p, t)
     du[1] = 2 - 2u[1]
     return du[2] = u[1] - 4u[2]
 end
 u0 = zeros(2)
-prob = SteadyStateProblem(f, u0)
+prob = SteadyStateProblem(f_steady, u0)
 
-@test_broken @inferred(SteadyStateProblem(f, u0)) == SteadyStateProblem(f, u0)
-@test SteadyStateProblem(ODEProblem(f, u0, tspan, :param)).p == :param
+@test_broken @inferred(SteadyStateProblem(f_steady, u0)) == SteadyStateProblem(f_steady, u0)
+@test SteadyStateProblem(ODEProblem(f_steady, u0, tspan, :param)).p == :param


### PR DESCRIPTION
## Summary
- Rename overwritten function definitions to unique names in test files to eliminate `WARNING: Method definition overwritten` messages (7 files)
- Add `local` keyword to disambiguate soft scope assignments in test loops and `@test_broken` blocks (4 files)
- Replace deprecated ModelingToolkit APIs: `ODESystem` → `System`, `NonlinearSystem` → `System`, `structural_simplify` → `mtkcompile`
- Replace deprecated `sol[end]` indexing with `sol.u[end]` for RecursiveArrayTools compatibility
- Fix function signatures (add missing `p` parameter) that were previously hidden by method accumulation on shared `f` generic

## Details

### Method redefinition warnings fixed
These test files defined multiple functions named `f` with different signatures, causing `WARNING: Method definition f(...) overwritten` messages in CI:
- `test/problem_creation_tests.jl` — renamed to `f_ode`, `f_2ndorder`, `f_sde`, `g_sde`, `f_dae`, `f_rode`, `f_discrete`, `f_steady`
- `test/forwarddiff_dual_detection.jl` — renamed to `f_nlsolve`, `f_1021`
- `test/downstream/solve_error_handling.jl` — renamed to `f_oop`, `f_iip`, `f_sde`
- `test/downstream/community_callback_tests.jl` — renamed to `collision_affect!`, `terminate_affect!`
- `test/downstream/distributed_ensemble.jl` — renamed to `simple_prob_func`, `lorenz_prob_func`

### Soft scope warnings fixed
- `test/downstream/kwarg_warn.jl` — removed unnecessary `sol =` assignment in `@test_throws`
- `test/downstream/solve_error_handling.jl` — added `local` in `for` loop, removed unnecessary assignment
- `test/downstream/null_de.jl` — added `local` in `for` loop
- `test/downstream/default_linsolve_structure.jl` — added `local` in `@test_broken` blocks

### Deprecated API replacements
- `test/downstream/null_de.jl` — `ODESystem` → `System`, `NonlinearSystem` → `System`, `structural_simplify` → `mtkcompile`
- `test/downstream/subarray_support.jl` — `sol[end]` → `sol.u[end]`

## Test plan
- [x] Core tests pass locally with `--depwarn=yes`
- [x] No method redefinition warnings remain in core tests
- [x] Runic formatting check passes on all changed files
- [ ] CI should pass on all test groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)