### PR TITLE
Fix Incompatability -> Incompatibility typo to match SciMLBase

### DIFF
--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -99,8 +99,8 @@ import SciMLBase: solve, init, step!, solve!, __init, __solve, update_coefficien
     isconcreteu0, isconcretedu0, get_concrete_du0, _reshape, value, unitfulvalue, anyeltypedual, allowedkeywords,
     sse, totallength, __sum, DualEltypeChecker, KeywordArgError, KeywordArgWarn, KeywordArgSilent, KWARGWARN_MESSAGE, KWARGERROR_MESSAGE,
     CommonKwargError, IncompatibleInitialConditionError, NO_DEFAULT_ALGORITHM_MESSAGE, NoDefaultAlgorithmError, NO_TSPAN_MESSAGE, NoTspanError,
-    NAN_TSPAN_MESSAGE, NaNTspanError, NON_SOLVER_MESSAGE, NonSolverError, NOISE_SIZE_MESSAGE, NoiseSizeIncompatabilityError, PROBSOLVER_PAIRING_MESSAGE,
-    ProblemSolverPairingError, compatible_problem_types, DIRECT_AUTODIFF_INCOMPATABILITY_MESSAGE, DirectAutodiffError, NONNUMBER_ELTYPE_MESSAGE, NonNumberEltypeError,
+    NAN_TSPAN_MESSAGE, NaNTspanError, NON_SOLVER_MESSAGE, NonSolverError, NOISE_SIZE_MESSAGE, NoiseSizeIncompatibilityError, PROBSOLVER_PAIRING_MESSAGE,
+    ProblemSolverPairingError, compatible_problem_types, DIRECT_AUTODIFF_INCOMPATIBILITY_MESSAGE, DirectAutodiffError, NONNUMBER_ELTYPE_MESSAGE, NonNumberEltypeError,
     GENERIC_NUMBER_TYPE_ERROR_MESSAGE, GenericNumberTypeError, COMPLEX_SUPPORT_ERROR_MESSAGE, ComplexSupportError, COMPLEX_TSPAN_ERROR_MESSAGE, ComplexTspanError,
     TUPLE_STATE_ERROR_MESSAGE, TupleStateError, MASS_MATRIX_ERROR_MESSAGE, IncompatibleMassMatrixError, LATE_BINDING_TSTOPS_ERROR_MESSAGE, LateBindingTstopsNotSupportedError,
     NONCONCRETE_ELTYPE_MESSAGE, NonConcreteEltypeError, _vec

--- a/src/solve.jl
+++ b/src/solve.jl
@@ -866,7 +866,7 @@ function check_prob_alg_pairing(prob, alg)
             prob.noise !== nothing &&
             size(prob.noise_rate_prototype, 2) != length(prob.noise.W[1])
         throw(
-            NoiseSizeIncompatabilityError(
+            NoiseSizeIncompatibilityError(
                 size(prob.noise_rate_prototype, 2),
                 length(prob.noise.W[1])
             )

--- a/test/downstream/solve_error_handling.jl
+++ b/test/downstream/solve_error_handling.jl
@@ -73,7 +73,7 @@ prob = SDEProblem(
     noise_rate_prototype = complex(zeros(2, 4)),
     noise = StochasticDiffEq.RealWienerProcess(0.0, zeros(3))
 )
-@test_throws SciMLBase.NoiseSizeIncompatabilityError solve(prob, LambaEM())
+@test_throws SciMLBase.NoiseSizeIncompatibilityError solve(prob, LambaEM())
 
 function g!(du, u, p, t)
     du[1] .= u[1] + ones(3, 3)


### PR DESCRIPTION
## Summary
- Update `NoiseSizeIncompatabilityError` → `NoiseSizeIncompatibilityError` in re-exports, usage, and tests
- Update `DIRECT_AUTODIFF_INCOMPATABILITY_MESSAGE` → `DIRECT_AUTODIFF_INCOMPATIBILITY_MESSAGE` in re-exports
- Fixes downstream test failure caused by SciML/SciMLBase.jl#1231 which corrected the typo in SciMLBase

## Files changed
- `src/DiffEqBase.jl` - Updated re-export names
- `src/solve.jl` - Updated error constructor call
- `test/downstream/solve_error_handling.jl` - Updated test assertion

## Test plan
- [ ] CI passes with updated SciMLBase that has the renamed error types

🤖 Generated with [Claude Code](https://claude.com/claude-code)