### PR TITLE
Revert ModAB bracketing solver (PR #1273) — breaks ForwardDiff AD with callbacks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -68,7 +68,7 @@ DiffEqBaseUnitfulExt = "Unitful"
 [compat]
 ADTypes = "1"
 ArrayInterface = "7.8"
-BracketingNonlinearSolve = "1.7.1"
+BracketingNonlinearSolve = "1.6.2"
 CUDA = "5"
 ChainRulesCore = "1"
 ConcreteStructs = "0.2.3"

--- a/src/DiffEqBase.jl
+++ b/src/DiffEqBase.jl
@@ -113,7 +113,7 @@ Reexport.@reexport using SciMLBase
 SciMLBase.isfunctionwrapper(x::FunctionWrapper) = true
 
 # Rootfinder for callbacks
-using BracketingNonlinearSolve: ModAB
+using BracketingNonlinearSolve: ITP
 
 import SymbolicIndexingInterface as SII
 

--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -390,7 +390,7 @@ Assumes that:
 function find_root(f, tup, rootfind::SciMLBase.RootfindOpt)
     sol = solve(
         IntervalNonlinearProblem{false}(f, tup),
-        ModAB(), abstol = 0.0, reltol = 0.0
+        ITP(), abstol = 0.0, reltol = 0.0
     )
     if rootfind == SciMLBase.LeftRootFind
         return sol.left

--- a/test/downstream/null_de.jl
+++ b/test/downstream/null_de.jl
@@ -35,7 +35,7 @@ end
 @variables x(t) y(t)
 eqs = [
     0 ~ x - y
-    0 ~ y
+    0 ~ y - x
 ]
 
 @named sys = System(eqs, t)
@@ -67,7 +67,7 @@ end
 @variables x y
 eqs = [
     0 ~ x - y
-    0 ~ y
+    0 ~ y - x
 ]
 
 @named sys = System(eqs, [x, y], [])
@@ -157,13 +157,12 @@ end
     @test sol_no_cb.t == [0.0, 1.0]
 
     # Test 2: has_callbacks detection - null problem WITH callbacks should NOT take fast path
-    # But works in OrdinaryDiffEq.jl path
+    # This will error because OrdinaryDiffEq can't handle null u0 with callbacks yet,
+    # but the error proves we're not silently skipping callbacks
     callback_called = Ref(false)
     cb = DiscreteCallback((u, t, integrator) -> t >= 0.5, integrator -> callback_called[] = true)
     prob_with_cb = ODEProblem(Returns(nothing), nothing, (0.0, 1.0))
-    sol = solve(prob_with_cb, Tsit5(); callback = cb, tstops = [0.5])
-    @test sol.retcode == SciMLBase.ReturnCode.Success
-    @test callback_called[]
+    @test_throws Exception solve(prob_with_cb, Tsit5(); callback = cb)
 
     # Test 3: ODE with state + DiscreteCallback - callbacks should trigger
     # Using raw ODE (not MTK) to avoid API changes
@@ -178,8 +177,6 @@ end
     @test sol_with_state.retcode == SciMLBase.ReturnCode.Success
     @test callback_triggered[]
 
-    # Test 4: init with null problem + callback works in OrdinaryDiffEq.jl path
-    sol = solve(prob_with_cb, Tsit5(); callback = cb)
-    @test sol.retcode == SciMLBase.ReturnCode.Success
-    @test callback_triggered[]
+    # Test 4: init with null problem + callback should also not take fast path
+    @test_throws Exception init(prob_with_cb, Tsit5(); callback = cb)
 end


### PR DESCRIPTION
## Summary

Reverts PR #1273 which switched the bracketing solver to `ModAB`. This change breaks ForwardDiff automatic differentiation through ODE solves using `ContinuousCallback`.

## Problem

With `ModAB` bracketing, ForwardDiff Dual numbers produce NaN step errors and wildly incorrect Jacobians during callback event detection. Verified by bisecting DiffEqBase versions:

- **v6.203.0** (before #1273): 0/101 AD test failures
- **v6.204.0** (with #1273): 17/101 AD test failures

See #1275 for full reproduction script.

## Test plan

- [ ] Verify AD tests pass with this revert
- [ ] Verify existing DiffEqBase tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Chris Rackauckas <accounts@chrisrackauckas.com>