### PR TITLE
Fix GPU scalar indexing in VectorContinuousCallback

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -206,10 +206,10 @@ end
         end
 
         # Evaluate condition slightly in future
-        nudged_t = nudge_tprev(integrator, callback, bottom_condition[nudged_idx])
+        nudged_t = nudge_tprev(integrator, callback, ArrayInterface.allowed_getindex(bottom_condition, nudged_idx))
         tmp_condition = get_condition(integrator, callback, nudged_t)
 
-        bottom_sign[nudged_idx] = sign(tmp_condition[nudged_idx])
+        ArrayInterface.allowed_setindex!(bottom_sign, sign(ArrayInterface.allowed_getindex(tmp_condition, nudged_idx)), nudged_idx)
     else
         nudged_idx = -1
         nudged_t = bottom_t
@@ -226,7 +226,13 @@ end
         residual = zero(eltype(bottom_condition))
     elseif isdiscrete(integrator.alg) || callback.rootfind == SciMLBase.NoRootFind
         callback_t = top_t
-        min_event_idx = findfirst(isequal(1), event_idx)
+        min_event_idx = 1
+        for i in 1:length(event_idx)
+            if ArrayInterface.allowed_getindex(event_idx, i) == 1
+                min_event_idx = i
+                break
+            end
+        end
         residual = zero(eltype(bottom_condition))
     else
         callback_t = rightfloat(top_t, integrator.tdir)


### PR DESCRIPTION
## Summary
- Replace plain `[]` indexing with `ArrayInterface.allowed_getindex`/`allowed_setindex!` in `find_callback_time` for `VectorContinuousCallback`
- Fixes "Scalar indexing is disallowed" errors when using `VectorContinuousCallback` with `EnsembleGPUArray`
- Three locations fixed: `bottom_condition[nudged_idx]`, `bottom_sign[nudged_idx] = sign(tmp_condition[nudged_idx])`, and `findfirst(isequal(1), event_idx)` replaced with `allowed_getindex` loop

## Context
When `CallbackCache` is constructed with a GPU array `u`, the cache arrays (`prev_sign`, `next_sign`, `tmp_condition`, `next_condition`) are GPU arrays via `similar(u, ...)`. The existing code at lines 209, 212, and 229 used plain `[]` indexing on these arrays, triggering GPU scalar indexing errors.

The rest of the function (lines 235, 237-243, 245, 267) already correctly uses `ArrayInterface.allowed_getindex`, which has a GPU override in `ArrayInterfaceGPUArraysCoreExt.jl` that wraps accesses in `@allowscalar`. This PR makes the remaining accesses consistent.

## Test plan
- [x] `Pkg.test()` passes locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)