### PR TITLE
Handle MixedDuplicated in Enzyme custom rules for solve_up

### DIFF
--- a/ext/DiffEqBaseEnzymeExt.jl
+++ b/ext/DiffEqBaseEnzymeExt.jl
@@ -4,7 +4,7 @@ module DiffEqBaseEnzymeExt
     using DiffEqBase
     import DiffEqBase: value
     using Enzyme
-    import Enzyme: Const
+    import Enzyme: Const, MixedDuplicated
     using ChainRulesCore
 
 
@@ -31,7 +31,7 @@ module DiffEqBaseEnzymeExt
 
     function Enzyme.EnzymeRules.augmented_primal(
             config::Enzyme.EnzymeRules.RevConfigWidth{1},
-            func::Const{typeof(DiffEqBase.solve_up)}, RTA::Type{Duplicated{RT}}, prob,
+            func::Const{typeof(DiffEqBase.solve_up)}, RTA::Union{Type{Duplicated{RT}}, Type{MixedDuplicated{RT}}}, prob,
             sensealg::Union{
                 Const{Nothing}, Const{<:DiffEqBase.AbstractSensitivityAlgorithm},
             },
@@ -66,7 +66,7 @@ module DiffEqBaseEnzymeExt
 
     function Enzyme.EnzymeRules.reverse(
             config::Enzyme.EnzymeRules.RevConfigWidth{1},
-            func::Const{typeof(DiffEqBase.solve_up)}, ::Type{Duplicated{RT}}, tape, prob,
+            func::Const{typeof(DiffEqBase.solve_up)}, ::Union{Type{Duplicated{RT}}, Type{MixedDuplicated{RT}}}, tape, prob,
             sensealg::Union{
                 Const{Nothing}, Const{<:DiffEqBase.AbstractSensitivityAlgorithm},
             },
@@ -84,7 +84,11 @@ module DiffEqBaseEnzymeExt
                 if darg == ChainRulesCore.NoTangent()
                     continue
                 end
-                ptr.dval .+= darg
+                if ptr isa MixedDuplicated
+                    ptr.dval[] .+= darg
+                else
+                    ptr.dval .+= darg
+                end
             end
             Enzyme.make_zero!(dres.u)
         end


### PR DESCRIPTION
## Summary

- Accept `MixedDuplicated{RT}` (in addition to `Duplicated{RT}`) in both `augmented_primal` and `reverse` Enzyme rules for `solve_up`
- Handle `MixedDuplicated` argument shadow access in reverse pass (`.dval[]` instead of `.dval`)
- Import `MixedDuplicated` from Enzyme

## Context

When Enzyme determines that `ODESolution` has mixed activity state (both mutable arrays like `sol.u` and immutable scalar fields), it annotates the return as `MixedDuplicated` instead of `Duplicated`. The existing rules only matched `Duplicated{RT}`, so Enzyme fell through to JIT rules which fail with:

```
MethodError: no method matching MixedDuplicated(::ODESolution{...}, ::ODESolution{...})
```

This is one of the errors reported in SciML/SciMLSensitivity.jl#1359 (attempt 3: `set_runtime_activity(Reverse)` + `Const(loss)`).

## Testing

Verified that:
1. The extension loads correctly and the rule signature matches both `Duplicated` and `MixedDuplicated` return types
2. The custom rule IS dispatched (confirmed via stacktrace showing `augmented_primal at DiffEqBaseEnzymeExt.jl:32`)

Note: The full MWE from SciMLSensitivity.jl#1359 still hits additional issues:
- On Julia 1.12: `Enzyme.make_zero` segfaults on complex `ODESolution` types (GC bug in Julia/Enzyme interaction)
- `NonlinearSolveBase`'s Enzyme extension also needs the same `MixedDuplicated` fix for DAE initialization
- There may be upstream Enzyme issues with `MixedDuplicated` shadow creation in JIT rules

A corresponding fix for `NonlinearSolveBase` should also be made.

## Test plan

- [ ] Verify extension loads and rule signature matches `MixedDuplicated`
- [ ] Test with simple ODE problems (non-MTK) using `set_runtime_activity(Reverse)`
- [ ] Test with MTK DAE problems once Enzyme GC issues are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)