### PR TITLE
Unwrap AD types in last_event_error to fix ReverseDiff callback crash

### DIFF
--- a/src/callbacks.jl
+++ b/src/callbacks.jl
@@ -175,7 +175,7 @@ end
     ex = quote
         $ex
         if event_occurred
-            integrator.last_event_error = residual
+            integrator.last_event_error = value(residual)
         end
         return tmin, upcrossing, event_occurred, event_idx, identified_idx, $N
     end


### PR DESCRIPTION
## Summary

- Wrap `residual` with `value()` before assigning to `integrator.last_event_error` in `find_first_continuous_callback` to handle AD types that cannot be converted to `Float64`
- Add downstream regression test for Zygote gradient through `ContinuousCallback`

## Problem

When computing gradients via Zygote/SciMLSensitivity with `ReverseDiffAdjoint`, the callback condition function returns `ReverseDiff.TrackedReal` values. The `find_first_continuous_callback` generated function (callbacks.jl:178) stores the callback residual in `integrator.last_event_error`, which is typed as `Float64`. Since `ReverseDiff.TrackedReal` intentionally disallows `convert(Float64, ...)` to prevent silent loss of gradient tracking, this causes:

```
ArgumentError: Converting an instance of ReverseDiff.TrackedReal{Float64, ...} to Float64 
is not defined. Please use `ReverseDiff.value` instead.
```

This breaks the AD test in [OrdinaryDiffEq.jl PR #3046](https://github.com/SciML/OrdinaryDiffEq.jl/pull/3046) (jobs `test (AD, lts)` and `test (AD, 1.11)`).

## Fix

`last_event_error` is only used in `nudge_tprev` for a numerical comparison to decide whether to nudge the previous event time — it is not part of the gradient computation graph. Using `value()` (already defined in SciMLBase with extensions for all AD types) safely extracts the numeric value.

## Test plan

- [x] Core tests pass (`Pkg.test(; test_args=["Core"])`)
- [x] Existing ForwardDiff callback AD downstream tests pass
- [x] New Zygote callback AD downstream test passes (was crashing before the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)